### PR TITLE
Add jest dev dependency

### DIFF
--- a/crypto-tracker-bot/package.json
+++ b/crypto-tracker-bot/package.json
@@ -8,6 +8,9 @@
     "server": "node server/server.js",
     "test": "jest"
   },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
   "dependencies": {
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",


### PR DESCRIPTION
## Summary
- include jest as a devDependency in crypto-tracker-bot

## Testing
- `npm test` *(fails: jest: not found)*

## Summary by Sourcery

Tests:
- Add jest as a devDependency to allow the `npm test` command to run successfully