### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
     "axios": "^1.9.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "multer": "^2.0.0",
-    "devDependencies": { "jest": "^29.7.0" }
-
+    "multer": "^2.0.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- clean up root package.json so devDependencies aren't nested under dependencies

## Testing
- `npm test` in `crypto-tracker-bot` *(fails: jest not found)*

## Summary by Sourcery

Bug Fixes:
- Fix nested devDependencies in package.json so Jest is installed correctly