### PR TITLE
Replace jest with Node test runner

### DIFF
--- a/crypto-tracker-bot/__tests__/logger.test.js
+++ b/crypto-tracker-bot/__tests__/logger.test.js
@@ -1,10 +1,12 @@
+const assert = require('assert');
+const test = require('node:test');
 const logger = require('../utils/logger');
 
-describe('logger', () => {
-  it('logs info messages', () => {
-    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
-    logger.info('hello');
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
-  });
+test('logger.info logs messages', () => {
+  const logged = [];
+  const original = console.log;
+  console.log = (...args) => logged.push(args);
+  logger.info('hello');
+  console.log = original;
+  assert(logged.length > 0);
 });

--- a/crypto-tracker-bot/package.json
+++ b/crypto-tracker-bot/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node bot.js",
     "server": "node server/server.js",
-    "test": "node --test"
+    "test": "node --test=__tests__"
   },
   "devDependencies": {},
   "dependencies": {

--- a/crypto-tracker-bot/package.json
+++ b/crypto-tracker-bot/package.json
@@ -6,11 +6,9 @@
   "scripts": {
     "start": "node bot.js",
     "server": "node server/server.js",
-    "test": "jest"
+    "test": "node --test"
   },
-  "devDependencies": {
-    "jest": "^29.7.0"
-  },
+  "devDependencies": {},
   "dependencies": {
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
     "axios": "^1.9.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "multer": "^2.0.0",
-    "devDependencies": { "jest": "^29.7.0" }
-
-  }
+    "multer": "^2.0.0"
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
## Summary
- drop jest and use Node's built-in test runner
- update logger test
- clean up devDependencies in package.json files

## Testing
- `npm test --silent` in `crypto-tracker-bot`

## Summary by Sourcery

Replace Jest with Node's built-in test runner by updating test scripts, migrating tests, and cleaning up dependencies.

Tests:
- Migrate logger test to use node:test and assert instead of Jest
- Update package.json test scripts to use "node --test"

Chores:
- Remove Jest from devDependencies in both package.json files