### PR TITLE
Fix indicator calculator ADX retrieval

### DIFF
--- a/trading_bot/indicator_calculator.py
+++ b/trading_bot/indicator_calculator.py
@@ -12,9 +12,10 @@ def add_indicators(df: pd.DataFrame) -> pd.DataFrame:
     adx = ta.adx(df["high"], df["low"], df["close"], length=14)
     if isinstance(adx, pd.DataFrame) and "ADX_14" in adx:
         df["adx"] = adx["ADX_14"]
+    elif isinstance(adx, (pd.Series, list)):
+        df["adx"] = adx
     else:
         df["adx"] = pd.NA
-    df["adx"] = ta.adx(df["high"], df["low"], df["close"], length=14)["ADX_14"]
     df["ema"] = ta.ema(df["close"], length=20)
     df["sma"] = ta.sma(df["close"], length=20)
 


### PR DESCRIPTION
## Summary
- handle various forms of ADX data from pandas_ta

## Testing
- `npm test`
- `(cd crypto-tracker-bot && npm test)`
- `python -m pytest trading_bot/tests`

------
https://chatgpt.com/codex/tasks/task_e_685f7bb6b4d4832bbb0773d6e0f85ae3

## Summary by Sourcery

Fix ADX indicator retrieval in add_indicators to correctly handle DataFrame, Series, and list outputs and remove redundant assignment.

Bug Fixes:
- Remove redundant unconditional override of df['adx'] that prevented proper assignment

Enhancements:
- Support Series and list outputs from pandas_ta.adx for assigning ADX values