### PR TITLE
Add telegram chat ID configuration

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -13,5 +13,7 @@ Contributions and suggestions are welcome.
 
 - **Webhook Notifications**: Send trade alerts and model signals via email or messaging platforms.
 - **Docker Deployment**: Provide a container image for easier setup on various systems.
+- **Expanded Alerts**: Allow configuration of multiple Telegram chats and Discord channels.
+- **Historical Analysis**: Store long-term price data for deeper trend exploration.
 
 

--- a/crypto-tracker-bot/README.md
+++ b/crypto-tracker-bot/README.md
@@ -12,6 +12,7 @@ Set the following variables in a `.env` file inside `crypto-tracker-bot/`:
 - `NEWSAPI_KEY` – News API token for news headlines
 - `DISCORD_WEBHOOK_URL` – Discord webhook URL for notifications
 - `TELEGRAM_BOT_TOKEN` – Telegram bot token used to send messages
+- `TELEGRAM_CHAT_ID` – Telegram chat ID where messages will be sent
 - `SLACK_WEBHOOK_URL` – Slack webhook URL for alerts
 - `PRICE_MOVEMENT_THRESHOLD` – Default percent change that triggers alerts (optional)
 - `POLL_INTERVAL` – How often prices are fetched in milliseconds (optional)

--- a/crypto-tracker-bot/config.js
+++ b/crypto-tracker-bot/config.js
@@ -6,6 +6,7 @@ module.exports = {
   newsApiKey: process.env.NEWSAPI_KEY,
   discordWebhookUrl: process.env.DISCORD_WEBHOOK_URL,
   telegramBotToken: process.env.TELEGRAM_BOT_TOKEN,
+  telegramChatId: process.env.TELEGRAM_CHAT_ID,
   slackWebhookUrl: process.env.SLACK_WEBHOOK_URL,
   chatGPTApiKey: process.env.CHATGPT_API_KEY,
   priceMovementThreshold: parseFloat(process.env.PRICE_MOVEMENT_THRESHOLD) || 5,

--- a/crypto-tracker-bot/notifier/telegramNotifier.js
+++ b/crypto-tracker-bot/notifier/telegramNotifier.js
@@ -6,8 +6,8 @@ async function sendTelegramMessage(message) {
   try {
     const url = `https://api.telegram.org/bot${config.telegramBotToken}/sendMessage`;
     await axios.post(url, {
-      chat_id: 'YOUR_TELEGRAM_CHAT_ID', // Replace with your actual chat id
-      text: message
+      chat_id: config.telegramChatId,
+      text: message,
     });
   } catch (error) {
     logger.error("Telegram notification error:", error);


### PR DESCRIPTION
## Summary
- configure telegram chat ID in config.js
- use configured chat ID when sending Telegram notifications
- document new `TELEGRAM_CHAT_ID` environment variable
- propose additional features in PROPOSALS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f7efbd58c832b8fa69119ad8cb10b

## Summary by Sourcery

Enable configurable Telegram chat IDs for notifications and update related documentation and proposals.

New Features:
- Allow specifying the Telegram chat ID via an environment variable
- Apply the configured Telegram chat ID when sending notifications

Documentation:
- Document the `TELEGRAM_CHAT_ID` variable in the README
- Add multi-chat and historical analysis proposals to PROPOSALS.md