### PR TITLE
Add chart visualizations for analysis

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -13,5 +13,6 @@ Contributions and suggestions are welcome.
 
 - **Webhook Notifications**: Send trade alerts and model signals via email or messaging platforms.
 - **Docker Deployment**: Provide a container image for easier setup on various systems.
+- **Interactive Charting**: Visualize sentiment and technical indicators directly in the web client using Chart.js, allowing users to quickly interpret market data.
 
 

--- a/crypto-tracker-bot/client/main.js
+++ b/crypto-tracker-bot/client/main.js
@@ -7,6 +7,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const notificationLeft = document.getElementById('notification-left');
   const notificationRight = document.getElementById('notification-right');
   const ticker = document.getElementById('ticker');
+  let sentimentChart;
+  let technicalChart;
   // Initialize TradingView widget
   new TradingView.widget({
     container_id: "tradingview_chart",
@@ -62,6 +64,28 @@ document.addEventListener('DOMContentLoaded', () => {
     tickerIndex++;
   }
 
+  function calculateSentimentCounts(text) {
+    const positiveWords = ['bullish', 'positive', 'buy', 'growth', 'uptrend'];
+    const negativeWords = ['bearish', 'negative', 'sell', 'downtrend', 'decline'];
+    const lower = text.toLowerCase();
+    const countWords = (words) => words.reduce((acc, w) => acc + (lower.match(new RegExp(w, 'g')) || []).length, 0);
+    return {
+      positive: countWords(positiveWords),
+      negative: countWords(negativeWords)
+    };
+  }
+
+  function parseTechnicalIndicators(text) {
+    const indicators = {};
+    const capture = (label) => {
+      const regex = new RegExp(label + "[^0-9-]*(-?\\d+(?:\\.\\d+)?)", 'i');
+      const m = text.match(regex);
+      if (m) indicators[label.toUpperCase()] = parseFloat(m[1]);
+    };
+    ['RSI', 'MACD', 'SMA', 'EMA'].forEach(capture);
+    return indicators;
+  }
+
 
   // Toggle views
   toAnalysisBtn.addEventListener('click', () => {
@@ -98,9 +122,49 @@ document.addEventListener('DOMContentLoaded', () => {
       enhancedSentimentDiv.style.fontWeight = 'bold';
       document.getElementById('sentiment-text').appendChild(enhancedSentimentDiv);
 
-      // TODO: Render graphical sentiment and technical indicators here
-      document.getElementById('sentiment-graphical').textContent = '[Graphical sentiment visualization coming soon]';
-      document.getElementById('technical-graphical').textContent = '[Graphical technical indicators coming soon]';
+      // Render graphical sentiment and technical indicators
+      const sentimentCounts = calculateSentimentCounts(sentimentData.sentimentAnalysis || '');
+      const sentimentCtx = document.getElementById('sentiment-graphical').getContext('2d');
+      if (!sentimentChart) {
+        sentimentChart = new Chart(sentimentCtx, {
+          type: 'bar',
+          data: {
+            labels: ['Positive', 'Negative'],
+            datasets: [{
+              label: 'Sentiment Words',
+              data: [sentimentCounts.positive, sentimentCounts.negative],
+              backgroundColor: ['#28a745', '#dc3545']
+            }]
+          },
+          options: { responsive: true, maintainAspectRatio: false }
+        });
+      } else {
+        sentimentChart.data.datasets[0].data = [sentimentCounts.positive, sentimentCounts.negative];
+        sentimentChart.update();
+      }
+
+      const techIndicators = parseTechnicalIndicators(technicalData.technicalAnalysis || '');
+      const techCtx = document.getElementById('technical-graphical').getContext('2d');
+      const techLabels = Object.keys(techIndicators);
+      const techValues = Object.values(techIndicators);
+      if (!technicalChart) {
+        technicalChart = new Chart(techCtx, {
+          type: 'bar',
+          data: {
+            labels: techLabels,
+            datasets: [{
+              label: 'Indicator Values',
+              data: techValues,
+              backgroundColor: '#007bff'
+            }]
+          },
+          options: { responsive: true, maintainAspectRatio: false }
+        });
+      } else {
+        technicalChart.data.labels = techLabels;
+        technicalChart.data.datasets[0].data = techValues;
+        technicalChart.update();
+      }
 
     } catch (error) {
       console.error('Error fetching analysis:', error);


### PR DESCRIPTION
## Summary
- visualize sentiment and technical indicator data with Chart.js
- add helper functions to compute sentiment counts and parse indicators
- mention interactive charting in proposals

## Testing
- `npm test`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_685f7efd33cc832bb146b2274c9afd87

## Summary by Sourcery

Add interactive Chart.js visualizations for sentiment analysis and technical indicators in the web client using helper functions to compute sentiment counts and parse indicator values

New Features:
- Render sentiment analysis as a Chart.js bar chart showing positive and negative word counts
- Visualize technical indicators (RSI, MACD, SMA, EMA) as a Chart.js bar chart in the analysis view
- Introduce helper functions to compute sentiment word counts and parse technical indicator values

Documentation:
- Mention interactive Chart.js-based sentiment and technical indicator visualizations in PROPOSALS.md