### PR TITLE
Add tests for crypto tracker modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv/
 __pycache__/
 *.pyc
+node_modules/

--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -15,3 +15,9 @@ Contributions and suggestions are welcome.
 - **Docker Deployment**: Provide a container image for easier setup on various systems.
 
 
+
+## Crypto Tracker Bot Ideas
+
+- **Historical Price Storage**: Persist fetched prices to a database for long-term analysis.
+- **Trend Alerts**: Notify users when a coin moves beyond a configurable threshold.
+- **Web Dashboard**: Add a simple interface to view current prices and recent news.

--- a/crypto-tracker-bot/__tests__/cryptoTracker.test.js
+++ b/crypto-tracker-bot/__tests__/cryptoTracker.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('assert');
+const axios = require('axios');
+
+// module under test
+const { fetchPrices } = require('../monitoring/cryptoTracker');
+
+test('fetchPrices returns prices for all coins', async () => {
+  const original = axios.get;
+  const calls = [];
+  axios.get = async url => {
+    calls.push(url);
+    return { data: { last: { price: 42 } } };
+  };
+  const prices = await fetchPrices();
+  axios.get = original;
+  const coins = ['BTC', 'ETH', 'LTC', 'DOGE', 'SHIB', 'MATIC', 'LINK', 'AAVE', 'GRT', 'SAND'];
+  assert.strictEqual(calls.length, coins.length);
+  for (const coin of coins) {
+    assert.strictEqual(prices[coin], 42);
+  }
+});
+
+test('fetchPrices sets null when a request fails', async () => {
+  const original = axios.get;
+  let count = 0;
+  axios.get = async () => {
+    count++;
+    if (count === 2) throw new Error('fail');
+    return { data: { last: { price: count } } };
+  };
+  const prices = await fetchPrices();
+  axios.get = original;
+  assert.strictEqual(prices.BTC, 1);
+  assert.strictEqual(prices.ETH, null);
+});

--- a/crypto-tracker-bot/__tests__/newsTracker.test.js
+++ b/crypto-tracker-bot/__tests__/newsTracker.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('assert');
+const axios = require('axios');
+
+const { fetchNews } = require('../monitoring/newsTracker');
+
+test('fetchNews returns articles', async () => {
+  const original = axios.get;
+  axios.get = async () => ({ data: { articles: [{title: 'a'}] } });
+  const news = await fetchNews();
+  axios.get = original;
+  assert.deepStrictEqual(news, [{title: 'a'}]);
+});
+
+test('fetchNews throws on request error', async () => {
+  const original = axios.get;
+  axios.get = async () => { throw new Error('fail'); };
+  await assert.rejects(() => fetchNews());
+  axios.get = original;
+});

--- a/crypto-tracker-bot/__tests__/notifier.test.js
+++ b/crypto-tracker-bot/__tests__/notifier.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('assert');
+const axios = require('axios');
+
+// prepare env vars for config
+process.env.SLACK_WEBHOOK_URL = 'http://slack.test';
+process.env.DISCORD_WEBHOOK_URL = 'http://discord.test';
+process.env.TELEGRAM_BOT_TOKEN = 'token';
+
+// reload config-dependent modules
+delete require.cache[require.resolve('../config')];
+const { sendSlackMessage } = require('../notifier/slackNotifier');
+const { sendDiscordMessage } = require('../notifier/discordNotifier');
+const { sendTelegramMessage } = require('../notifier/telegramNotifier');
+const config = require('../config');
+
+test('sendSlackMessage posts to webhook', async () => {
+  const original = axios.post;
+  const calls = [];
+  axios.post = async (url, payload) => { calls.push({url, payload}); };
+  await sendSlackMessage('hi');
+  axios.post = original;
+  assert.deepStrictEqual(calls[0], { url: config.slackWebhookUrl, payload: { text: 'hi' } });
+});
+
+test('sendDiscordMessage posts to webhook', async () => {
+  const original = axios.post;
+  const calls = [];
+  axios.post = async (url, payload) => { calls.push({url, payload}); };
+  await sendDiscordMessage('hi');
+  axios.post = original;
+  assert.deepStrictEqual(calls[0], { url: config.discordWebhookUrl, payload: { content: 'hi' } });
+});
+
+test('sendTelegramMessage posts to API', async () => {
+  const original = axios.post;
+  const calls = [];
+  axios.post = async (url, payload) => { calls.push({url, payload}); };
+  await sendTelegramMessage('hello');
+  axios.post = original;
+  assert.ok(calls[0].url.includes('api.telegram.org/bot' + config.telegramBotToken));
+  assert.strictEqual(calls[0].payload.text, 'hello');
+});


### PR DESCRIPTION
## Summary
- add node_modules to `.gitignore`
- expand `PROPOSALS.md` with Crypto Tracker Bot ideas
- test `cryptoTracker` and `newsTracker` monitoring modules
- test notifier utilities for Slack, Discord and Telegram

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f7efe0eb8832ba07525da648eb0ee

## Summary by Sourcery

Add comprehensive unit tests for monitoring modules and notifier utilities, update proposal documentation with new bot ideas, and ignore node_modules in the repository

Enhancements:
- Expand PROPOSALS.md with new Crypto Tracker Bot ideas

Build:
- Add node_modules to .gitignore

Tests:
- Add unit tests for cryptoTracker.fetchPrices including success and failure cases
- Add unit tests for newsTracker.fetchNews including article retrieval and error handling
- Add unit tests for Slack, Discord, and Telegram notifier utilities