### PR TITLE
Add error handling tests

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -31,3 +31,8 @@ Contributions and suggestions are welcome.
 - **Trend Alerts**: Notify users when a coin moves beyond a configurable threshold.
 - **Web Dashboard**: Add a simple interface to view current prices and recent news.
 
+
+- **SMS Notifications**: Integrate with a service like Twilio to deliver urgent price or news alerts via text messages.
+- **Custom Polling Intervals**: Allow users to specify different polling rates per coin or news source to optimise API usage.
+- **News Sentiment Analysis**: Score fetched articles for positive or negative sentiment and include the rating in notifications.
+- **Interactive Charts**: Provide a lightweight dashboard showing historical price trends using Chart.js.

--- a/crypto-tracker-bot/__tests__/errorHandling.test.js
+++ b/crypto-tracker-bot/__tests__/errorHandling.test.js
@@ -1,0 +1,81 @@
+const test = require('node:test');
+const assert = require('assert');
+const axios = require('axios');
+
+const logger = require('../utils/logger');
+
+// reload modules that depend on config
+process.env.SLACK_WEBHOOK_URL = 'http://slack.test';
+process.env.DISCORD_WEBHOOK_URL = 'http://discord.test';
+process.env.TELEGRAM_BOT_TOKEN = 'token';
+process.env.TELEGRAM_CHAT_ID = 'chat';
+
+// clear config cache and reload notifiers
+delete require.cache[require.resolve('../config')];
+const { sendSlackMessage } = require('../notifier/slackNotifier');
+const { sendDiscordMessage } = require('../notifier/discordNotifier');
+const { sendTelegramMessage } = require('../notifier/telegramNotifier');
+const { fetchPrices } = require('../monitoring/cryptoTracker');
+const { fetchNews } = require('../monitoring/newsTracker');
+
+
+test('fetchPrices logs error when request fails', async () => {
+  const originalGet = axios.get;
+  const originalError = logger.error;
+  const errors = [];
+  axios.get = async () => { throw new Error('fail'); };
+  logger.error = (...args) => errors.push(args);
+  await fetchPrices().catch(() => {});
+  axios.get = originalGet;
+  logger.error = originalError;
+  assert.ok(errors.length > 0);
+});
+
+test('fetchNews logs error when request fails', async () => {
+  const originalGet = axios.get;
+  const originalError = logger.error;
+  const errors = [];
+  axios.get = async () => { throw new Error('fail'); };
+  logger.error = (...args) => errors.push(args);
+  await assert.rejects(() => fetchNews());
+  axios.get = originalGet;
+  logger.error = originalError;
+  assert.ok(errors.length > 0);
+});
+
+test('sendSlackMessage logs error on failure', async () => {
+  const originalPost = axios.post;
+  const originalError = logger.error;
+  const errors = [];
+  axios.post = async () => { throw new Error('fail'); };
+  logger.error = (...args) => errors.push(args);
+  await sendSlackMessage('hi');
+  axios.post = originalPost;
+  logger.error = originalError;
+  assert.ok(errors.length > 0);
+});
+
+test('sendDiscordMessage logs error on failure', async () => {
+  const originalPost = axios.post;
+  const originalError = logger.error;
+  const errors = [];
+  axios.post = async () => { throw new Error('fail'); };
+  logger.error = (...args) => errors.push(args);
+  await sendDiscordMessage('hi');
+  axios.post = originalPost;
+  logger.error = originalError;
+  assert.ok(errors.length > 0);
+});
+
+test('sendTelegramMessage logs error on failure', async () => {
+  const originalPost = axios.post;
+  const originalError = logger.error;
+  const errors = [];
+  axios.post = async () => { throw new Error('fail'); };
+  logger.error = (...args) => errors.push(args);
+  await sendTelegramMessage('hello');
+  axios.post = originalPost;
+  logger.error = originalError;
+  assert.ok(errors.length > 0);
+});
+


### PR DESCRIPTION
## Summary
- add tests covering error logging in notifier utilities and trackers
- propose additional features for the crypto tracker bot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f9d354920832b9a81eb5185250578

## Summary by Sourcery

Add error handling tests for notifier and tracker modules and update PROPOSALS.md with new feature proposals

Documentation:
- Extend PROPOSALS.md with proposals for SMS notifications, custom polling intervals, news sentiment analysis, and interactive charts

Tests:
- Add tests to verify error logging in fetchPrices and fetchNews when requests fail
- Add tests to verify error logging in sendSlackMessage, sendDiscordMessage, and sendTelegramMessage on failures