### PR TITLE
Add testing instructions and proposals

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -50,3 +50,10 @@ Contributions and suggestions are welcome.
 - **News Sentiment Analysis**: Score fetched articles for positive or negative sentiment and include the rating in notifications.
 - **Interactive Charts**: Provide a lightweight dashboard showing historical price trends using Chart.js.
 - **Multi-Timeframe Analysis**: Support indicators calculated on different timeframes for more robust signal generation.
+
+## Further Feature Ideas
+
+- **Integrated Backtesting UI**: Provide a graphical interface where users can configure strategies and visualize backtest results directly in the dashboard.
+- **Cloud Deployment Templates**: Offer Terraform or Docker Compose examples so the entire stack can be deployed easily to cloud providers.
+- **User Accounts & Permissions**: Add optional authentication with role-based permissions to restrict access to trading features.
+- **Automated Parameter Tuning**: Leverage optimization libraries to search over strategy parameters for the best historical performance.

--- a/README.md
+++ b/README.md
@@ -90,3 +90,17 @@ streamlit run trading_bot/app.py
 ```
 
 The dashboard fetches real-time market data, displays technical analysis, sentiment, and a simple machine learning signal. You can also run a backtest from the sidebar.
+
+## Running Tests
+
+Python unit tests are located under `trading_bot/tests`. Before executing them, install the required Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then run the test suite from the repository root:
+
+```bash
+PYTHONPATH=. pytest
+```


### PR DESCRIPTION
## Summary
- document installing requirements and running pytest
- propose new features for the project

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa53c3070832b98e7155656338798

## Summary by Sourcery

Document test setup in README and enrich PROPOSALS.md with additional feature ideas.

Documentation:
- Add instructions for installing dependencies and running pytest tests in README.md
- Extend PROPOSALS.md with new feature proposals including integrated backtesting UI, cloud deployment templates, user accounts & permissions, and automated parameter tuning