### PR TITLE
Update tests docs and add feature ideas

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -50,3 +50,6 @@ Contributions and suggestions are welcome.
 - **News Sentiment Analysis**: Score fetched articles for positive or negative sentiment and include the rating in notifications.
 - **Interactive Charts**: Provide a lightweight dashboard showing historical price trends using Chart.js.
 - **Multi-Timeframe Analysis**: Support indicators calculated on different timeframes for more robust signal generation.
+- **Arbitrage Signals**: Detect price discrepancies across exchanges and notify users of potential arbitrage opportunities.
+- **Staking Yield Tracker**: Monitor staking rewards for supported assets to help users optimize yield strategies.
+- **AI-Based Signals**: Explore machine learning models that combine price action and sentiment to generate trading signals.

--- a/crypto-tracker-bot/README.md
+++ b/crypto-tracker-bot/README.md
@@ -41,11 +41,12 @@ The server listens on port `3000` by default.
 
 ## Running Tests
 
-Unit tests are executed with Jest:
+This project uses Node's built-in test runner. The `npm test` command simply
+executes `node --test=__tests__`:
 
 ```bash
 npm test
 ```
 
-Ensure dependencies are installed before running tests.
+Make sure dependencies are installed before running tests.
 


### PR DESCRIPTION
## Summary
- clarify that the crypto tracker tests run using Node's builtin test runner
- propose additional features for the crypto tracker bot

## Testing
- `npm test --prefix crypto-tracker-bot`

------
https://chatgpt.com/codex/tasks/task_e_685fa5319640832bad5e592c96920dfe

## Summary by Sourcery

Clarify README tests instructions to reflect Node's built-in test runner and expand the PROPOSALS.md with new feature ideas

Documentation:
- Specify in README that tests run via Node’s built-in test runner instead of Jest
- Add arbitrage signals, staking yield tracker, and AI-based signals proposals to PROPOSALS.md