### PR TITLE
Fix node test recursion warning

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -50,3 +50,5 @@ Contributions and suggestions are welcome.
 - **News Sentiment Analysis**: Score fetched articles for positive or negative sentiment and include the rating in notifications.
 - **Interactive Charts**: Provide a lightweight dashboard showing historical price trends using Chart.js.
 - **Multi-Timeframe Analysis**: Support indicators calculated on different timeframes for more robust signal generation.
+- **Social Media Monitoring**: Incorporate trending data from Twitter and Reddit to enrich sentiment analysis.
+- **Automated Backtesting**: Evaluate trading strategies on historical data to gauge expected performance.

--- a/crypto-tracker-bot/package.json
+++ b/crypto-tracker-bot/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node bot.js",
     "server": "node server/server.js",
-    "test": "node --test=__tests__"
+    "test": "node --test"
   },
   "devDependencies": {},
   "dependencies": {


### PR DESCRIPTION
## Summary
- avoid recursion warnings by simplifying crypto-tracker-bot test command
- propose new crypto tracker bot features

## Testing
- `npm test`
- `(cd crypto-tracker-bot && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_685fa49fdc88832b894e785e06acd7bd

## Summary by Sourcery

Fix recursion warning in crypto-tracker-bot tests and expand the feature proposals list

Bug Fixes:
- Simplify crypto-tracker-bot "test" script to use "node --test" and avoid recursion warnings

Documentation:
- Add "Social Media Monitoring" and "Automated Backtesting" entries to PROPOSALS.md