### PR TITLE
Fix test imports and add README

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -50,3 +50,11 @@ Contributions and suggestions are welcome.
 - **News Sentiment Analysis**: Score fetched articles for positive or negative sentiment and include the rating in notifications.
 - **Interactive Charts**: Provide a lightweight dashboard showing historical price trends using Chart.js.
 - **Multi-Timeframe Analysis**: Support indicators calculated on different timeframes for more robust signal generation.
+
+### Proposed Enhancements
+
+- **Real-Time Data Streaming**: Leverage WebSocket connections for faster market updates instead of relying solely on REST polling.
+- **Pluggable Strategies**: Provide a base strategy interface so users can drop in custom Python modules without modifying core files.
+- **Backtest Report Generation**: Output performance metrics and plots after running the backtester for easier analysis.
+- **Containerized Deployment**: Offer Dockerfiles for both the Python dashboard and Node services to simplify installation.
+- **Mobile Notifications**: Integrate with push services like Pushover or Pushbullet to deliver alerts directly to smartphones.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# Testing Instructions
+
+To run the Python test suite, install the required dependencies first:
+
+```bash
+pip install -r requirements.txt
+```
+
+After installing the packages, execute the tests from the repository root:
+
+```bash
+pytest
+```

--- a/trading_bot/tests/test_backtester.py
+++ b/trading_bot/tests/test_backtester.py
@@ -1,4 +1,9 @@
+import sys
+import os
 import pandas as pd
+
+# Ensure imports work when running tests from the repository root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 from trading_bot.backtester import backtest
 
 def test_backtest_returns_balance():

--- a/trading_bot/tests/test_data_fetcher.py
+++ b/trading_bot/tests/test_data_fetcher.py
@@ -1,4 +1,8 @@
-import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import sys
+import os
+
+# Ensure the package can be imported when running tests from the repo root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 from unittest.mock import patch, MagicMock
 from trading_bot.data_fetcher import DataFetcher
 import pandas as pd

--- a/trading_bot/tests/test_ml_model.py
+++ b/trading_bot/tests/test_ml_model.py
@@ -1,5 +1,10 @@
+import sys
+import os
 import pandas as pd
 import numpy as np
+
+# Make sure the trading_bot package is importable when running tests from repo root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 from trading_bot.ml_model import PriceDirectionModel
 
 def test_model_train_predict():


### PR DESCRIPTION
## Summary
- document how to install Python requirements and run pytest
- fix Python test modules so they work when running tests from repo root
- propose new enhancements for the bots

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa48eb30c832ba180efb747873a0a

## Summary by Sourcery

Fix test import paths for repository-root execution, add testing instructions in a README, and propose new enhancement ideas in the PROPOSALS document

Enhancements:
- Add enhancement proposals for real-time data streaming, pluggable strategies, backtest report generation, containerized deployment, and mobile notifications to PROPOSALS.md

Documentation:
- Add a README.md under tests with instructions for installing dependencies and running pytest

Tests:
- Adjust sys.path in test modules to enable imports when running tests from the repository root