### PR TITLE
Add TradingView support

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -123,3 +123,10 @@ To further enhance the toolkit, the following ideas could be explored:
 - **Strategy Explorer**: Provide a sandbox to test various machine learning models and compare their performance.
 - **Telegram Execution Bot**: Allow trades to be triggered via secure Telegram commands for convenience.
 - **Automated Risk Controls**: Implement dynamic stop-loss and take-profit mechanisms that adapt to market volatility.
+
+### More Complementary Features
+
+- **Multi-Exchange Support**: Aggregate prices and execute trades across several exchanges for better liquidity.
+- **Custom Alert Rules**: Allow users to define thresholds or indicator-based triggers for personalized notifications.
+- **Portfolio Rebalancing Tools**: Provide automated routines to maintain desired asset allocations.
+- **Community Leaderboard**: Enable optional sharing of performance statistics to foster friendly competition.

--- a/crypto-tracker-bot/client/index.html
+++ b/crypto-tracker-bot/client/index.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" />
   <!-- Chart.js via CDN -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <!-- TradingView widget library -->
+  <script src="https://s3.tradingview.com/tv.js"></script>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -22,6 +24,7 @@
       <section class="mt-4">
         <h3>Live Price Graph</h3>
         <canvas id="priceChart" width="400" height="200"></canvas>
+        <div id="tradingview_chart" class="mt-4"></div>
       </section>
     <section class="mt-4">
       <h3>Select Cryptocurrencies to Track</h3>


### PR DESCRIPTION
## Summary
- load TradingView's widget library in the client
- show TradingView chart container on the page
- outline new complementary feature ideas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686003c08a6c832ba3f3db0901958c30

## Summary by Sourcery

Add support for TradingView charts in the client interface and expand the PROPOSALS document with new feature ideas.

New Features:
- Integrate TradingView's widget library into the client
- Render a TradingView chart container alongside the existing price graph

Documentation:
- Append a 'More Complementary Features' section to PROPOSALS.md with multi-exchange support, custom alert rules, portfolio rebalancing tools, and a community leaderboard