### PR TITLE
Fix sentiment view clearing

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -129,3 +129,5 @@ To further enhance the toolkit, the following ideas could be explored:
 - **Interactive TradingView Charts**: Embed TradingView widgets to provide professional-grade charting alongside existing graphs.
 - **Configurable Indicators**: Allow users to toggle popular indicators (e.g., RSI, MACD) directly within the TradingView widget.
 - **Multi-Asset Views**: Support displaying multiple charts simultaneously so traders can compare assets side by side.
+- **Customizable Alert Thresholds**: Let users set individual price or indicator levels that trigger notifications.
+- **Light/Dark Theme Toggle**: Offer switchable themes in the dashboard to improve readability in different environments.

--- a/crypto-tracker-bot/client/main.js
+++ b/crypto-tracker-bot/client/main.js
@@ -155,7 +155,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const enhancedSentimentData = await enhancedSentimentRes.json();
 
       // Display text analysis
-      document.getElementById('sentiment-text').textContent = sentimentData.sentimentAnalysis || 'No sentiment data';
+      const sentimentEl = document.getElementById('sentiment-text');
+      sentimentEl.textContent = '';
+      sentimentEl.append(document.createTextNode(sentimentData.sentimentAnalysis || 'No sentiment data'));
       document.getElementById('technical-text').textContent = technicalData.technicalAnalysis || 'No technical data';
 
       // Display enhanced sentiment analysis text
@@ -163,7 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
       enhancedSentimentDiv.textContent = enhancedSentimentData.enhancedSentimentAnalysis || 'No enhanced sentiment data';
       enhancedSentimentDiv.style.marginTop = '1em';
       enhancedSentimentDiv.style.fontWeight = 'bold';
-      document.getElementById('sentiment-text').appendChild(enhancedSentimentDiv);
+      sentimentEl.appendChild(enhancedSentimentDiv);
 
       // Render graphical sentiment and technical indicators
       updateSentimentChart(sentimentData.sentimentAnalysis);


### PR DESCRIPTION
## Summary
- clear sentiment-text before appending new analysis
- add proposal enhancements for alert thresholds and theme toggle

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68600adbc328832bbc5ecc17f302af85

## Summary by Sourcery

Clear existing sentiment text before appending new analysis and update PROPOSALS.md with customizable alert thresholds and light/dark theme toggle proposals.

Bug Fixes:
- Clear the sentiment view before appending new analysis.

Enhancements:
- Add proposals for customizable alert thresholds and light/dark theme toggle in PROPOSALS.md.