### PR TITLE
Fix duplicate API keys

### DIFF
--- a/crypto-tracker-bot/README.md
+++ b/crypto-tracker-bot/README.md
@@ -15,7 +15,7 @@ Set the following variables in a `.env` file inside `crypto-tracker-bot/`:
 - `TELEGRAM_CHAT_ID` – Telegram chat ID where messages will be sent. Set this to the desired chat or channel ID.
 - `SLACK_WEBHOOK_URL` – Slack webhook URL for alerts
 - `TIINGO_API_KEY` – Tiingo API token for additional news data
-- `CRYPTOPANICK_API_KEY` – API key for CryptoPanick news
+- `CRYPTO_PANICK_API_KEY` – API key for CryptoPanick news
 - `MARKETEUX_API_KEY` – Marketeux API key for curated articles
 - `ALPHA_VANTAGE_API_KEY` – Alpha Vantage API key for sentiment feed
 - `PRICE_MOVEMENT_THRESHOLD` – Default percent change that triggers alerts (optional)
@@ -23,10 +23,6 @@ Set the following variables in a `.env` file inside `crypto-tracker-bot/`:
 - `STORAGE_INTERVAL` – Interval for persisting price history in milliseconds (optional)
 - `GOOGLE_CLOUD_PROJECT_ID` – Google Cloud project ID used by Vertex AI
 - `GOOGLE_CLOUD_ACCESS_TOKEN` – Access token for the Google Cloud Vertex API
-- `TIINGO_API_KEY` – Tiingo News API key
-- `CRYPTO_PANICK_API_KEY` – CryptoPanick API key
-- `MARKETEUX_API_KEY` – Marketeux news API key
-- `ALPHAVANTAGE_API_KEY` – Alpha Vantage API key for sentiment data
 
 ## Running the Bot
 

--- a/crypto-tracker-bot/config.js
+++ b/crypto-tracker-bot/config.js
@@ -11,7 +11,7 @@ module.exports = {
   slackWebhookUrl: process.env.SLACK_WEBHOOK_URL,
   chatGPTApiKey: process.env.CHATGPT_API_KEY,
   tiingoApiKey: process.env.TIINGO_API_KEY,
-  cryptoPanickApiKey: process.env.CRYPTOPANICK_API_KEY,
+  cryptoPanickApiKey: process.env.CRYPTO_PANICK_API_KEY,
   marketeuxApiKey: process.env.MARKETEUX_API_KEY,
   alphaVantageApiKey: process.env.ALPHA_VANTAGE_API_KEY,
   priceMovementThreshold: parseFloat(process.env.PRICE_MOVEMENT_THRESHOLD) || 5,
@@ -19,8 +19,4 @@ module.exports = {
   storageInterval: parseInt(process.env.STORAGE_INTERVAL) || 300000,
   googleCloudProjectId: process.env.GOOGLE_CLOUD_PROJECT_ID,
   googleCloudAccessToken: process.env.GOOGLE_CLOUD_ACCESS_TOKEN,
-  tiingoApiKey: process.env.TIINGO_API_KEY,
-  cryptoPanickApiKey: process.env.CRYPTO_PANICK_API_KEY,
-  marketeuxApiKey: process.env.MARKETEUX_API_KEY,
-  alphaVantageApiKey: process.env.ALPHAVANTAGE_API_KEY,
 };


### PR DESCRIPTION
## Summary
- remove duplicate API key references from `config.js`
- standardize environment variable names in `crypto-tracker-bot/README.md`

## Testing
- `npm test --prefix crypto-tracker-bot` *(fails: cannot find module `better-sqlite3`)*
- `pytest -q` *(fails: missing packages `pandas`, `ccxt`)*

------
https://chatgpt.com/codex/tasks/task_e_68600e6f3d78832bb377b8d45674846a

## Summary by Sourcery

Standardize environment variable naming for the CryptoPanick API key and remove duplicate API key references in both the README and config.

Enhancements:
- Correct the reference to CRYPTO_PANICK_API_KEY in config.js and remove redundant API key properties.

Documentation:
- Remove duplicate API key entries and standardize environment variable names in the README.