### PR TITLE
Add weekly crypto summary script

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -130,6 +130,7 @@ To further enhance the toolkit, the following ideas could be explored:
 - **Multi-Exchange Support**: Aggregate prices and execute trades across several exchanges for better liquidity.
 - **Custom Alert Rules**: Allow users to define thresholds or indicator-based triggers for personalized notifications.
 - **Portfolio Rebalancing Tools**: Provide automated routines to maintain desired asset allocations.
+- **Automated Weekly Reports**: Compile and deliver a summary of prices and sentiment via Slack or email.
 - **Community Leaderboard**: Enable optional sharing of performance statistics to foster friendly competition.
 
 ### TradingView Widget Enhancements

--- a/crypto-tracker-bot/README.md
+++ b/crypto-tracker-bot/README.md
@@ -60,3 +60,13 @@ npm test
 
 Make sure dependencies are installed before running tests.
 
+
+## Weekly Market Reports
+
+The optional `weeklyReport.js` script compiles a short summary of recent prices and sentiment. By default it runs every Monday at 9 AM using `node-schedule`. Set the `WEEKLY_REPORT_CRON` environment variable to customise the schedule with a standard cron expression.
+
+Run the report manually with:
+
+```bash
+npm run weekly-report
+```

--- a/crypto-tracker-bot/__tests__/weeklyReport.test.js
+++ b/crypto-tracker-bot/__tests__/weeklyReport.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const weekly = require('../weeklyReport');
+const storage = require('../persist/storage');
+const sentimentAnalysis = require('../technicalIndicators/sentimentAnalysis');
+const slackNotifier = require('../notifier/slackNotifier');
+
+// stub data
+storage.getPriceHistory = () => [
+  { timestamp: 't1', data: { BTC: 100 } },
+  { timestamp: 't2', data: { BTC: 110 } }
+];
+
+sentimentAnalysis.analyzeData = async () => 'Positive';
+
+test('compileReport returns summary string', async () => {
+  const report = await weekly.compileReport();
+  assert.ok(report.includes('BTC price change: 10.00 USD (10.00%)'));
+  assert.ok(report.includes('Positive'));
+});
+
+test('sendReport posts to slack', async () => {
+  const messages = [];
+  slackNotifier.sendSlackMessage = async msg => messages.push(msg);
+  await weekly.sendReport();
+  assert.strictEqual(messages.length, 1);
+});

--- a/crypto-tracker-bot/package.json
+++ b/crypto-tracker-bot/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node bot.js",
     "server": "node server/server.js",
-    "test": "node --test"
+    "test": "node --test",
+    "weekly-report": "node weeklyReport.js"
   },
   "devDependencies": {},
   "dependencies": {
@@ -14,6 +15,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",
-    "better-sqlite3": "^9.0.2"
+    "better-sqlite3": "^9.0.2",
+    "node-schedule": "^2.1.1"
   }
 }

--- a/crypto-tracker-bot/weeklyReport.js
+++ b/crypto-tracker-bot/weeklyReport.js
@@ -1,0 +1,49 @@
+const storage = require('./persist/storage');
+const sentimentAnalysis = require('./technicalIndicators/sentimentAnalysis');
+const slackNotifier = require('./notifier/slackNotifier');
+const schedule = require('node-schedule');
+const logger = require('./utils/logger');
+
+async function compileReport() {
+  const history = storage.getPriceHistory();
+  if (history.length === 0) {
+    return 'Weekly report: no data available.';
+  }
+
+  // Use the last 7 entries as a simple "week" window
+  const lastWeek = history.slice(-7);
+  const first = lastWeek[0].data;
+  const last = lastWeek[lastWeek.length - 1].data;
+
+  const start = first.BTC;
+  const end = last.BTC;
+  const change = end - start;
+  const changePct = start ? (change / start) * 100 : 0;
+
+  let sentiment = '';
+  try {
+    sentiment = await sentimentAnalysis.analyzeData({ symbol: 'BTC', currentPrice: end, changePercent: changePct });
+  } catch (err) {
+    logger.error('Sentiment analysis failed:', err);
+  }
+
+  const report = `Weekly Market Summary\nBTC price change: ${change.toFixed(2)} USD (${changePct.toFixed(2)}%)\nSentiment: ${sentiment}`;
+  return report;
+}
+
+async function sendReport() {
+  const report = await compileReport();
+  await slackNotifier.sendSlackMessage(report);
+}
+
+function scheduleReport() {
+  const cron = process.env.WEEKLY_REPORT_CRON || '0 9 * * 1';
+  schedule.scheduleJob(cron, sendReport);
+  logger.info(`Weekly report scheduled with cron: ${cron}`);
+}
+
+if (require.main === module) {
+  scheduleReport();
+}
+
+module.exports = { compileReport, sendReport, scheduleReport };


### PR DESCRIPTION
## Summary
- send weekly market report using new `weeklyReport.js`
- allow scheduling via `WEEKLY_REPORT_CRON` and add `node-schedule` dependency
- document weekly reports in README
- add test coverage for weekly report
- mention automated weekly reports in PROPOSALS

## Testing
- `npm test --prefix crypto-tracker-bot`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68600eb940ec832bbe23bd3b77eceedf

## Summary by Sourcery

Implement a new weekly crypto market summary script with scheduling, configuration, documentation, and test coverage.

New Features:
- Add a weekly report script to compile and send a market summary of recent crypto prices and sentiment
- Schedule automated weekly reports with a customizable cron expression via WEEKLY_REPORT_CRON
- Provide an npm script for manual execution of the weekly report

Enhancements:
- Document the weekly report feature in README and list it as a proposal in PROPOSALS.md

Build:
- Add node-schedule dependency and configure a "weekly-report" npm script in package.json

Tests:
- Introduce tests for report compilation and Slack notification