### PR TITLE
Add strategy interface and update backtester

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,29 @@ auto_install_and_run.sh
 requirements.txt      # Python dependencies
 ```
 
+## Custom Strategies
+
+The backtester accepts any strategy class located in `trading_bot/strategies/`.
+Create a module in that folder and subclass `Strategy`:
+
+```python
+from trading_bot.strategies.base import Strategy
+import pandas as pd
+
+class MyStrategy(Strategy):
+    def generate_signals(self, df: pd.DataFrame) -> float:
+        # Implement trading logic and return a final balance
+        return 1.0
+
+```
+
+Run the backtest with your strategy:
+
+```python
+from trading_bot.backtester import backtest
+from trading_bot.strategies.my_strategy import MyStrategy
+
+result = backtest(df, strategy=MyStrategy())
+```
+
 For more feature ideas, see `PROPOSALS.md`.

--- a/trading_bot/backtester.py
+++ b/trading_bot/backtester.py
@@ -1,20 +1,30 @@
+from typing import Optional
+
 import pandas as pd
 
-
-def simple_strategy(df: pd.DataFrame):
-    position = 0
-    balance = 1.0
-    for _, row in df.iterrows():
-        if row['close'] > row['vwap'] and row['rsi'] < 30 and position == 0:
-            position = balance / row['close']
-            balance = 0
-        elif position and (row['close'] < row['vwap'] or row['rsi'] > 70):
-            balance = position * row['close']
-            position = 0
-    if position:
-        balance = position * df.iloc[-1]['close']
-    return balance
+from trading_bot.strategies.base import Strategy
 
 
-def backtest(df: pd.DataFrame) -> float:
-    return simple_strategy(df)
+class SimpleStrategy(Strategy):
+    """Reimplements the original hard-coded logic as a strategy class."""
+
+    def generate_signals(self, df: pd.DataFrame) -> float:
+        position = 0
+        balance = 1.0
+        for _, row in df.iterrows():
+            if row['close'] > row['vwap'] and row['rsi'] < 30 and position == 0:
+                position = balance / row['close']
+                balance = 0
+            elif position and (row['close'] < row['vwap'] or row['rsi'] > 70):
+                balance = position * row['close']
+                position = 0
+        if position:
+            balance = position * df.iloc[-1]['close']
+        return balance
+
+
+def backtest(df: pd.DataFrame, strategy: Optional[Strategy] = None) -> float:
+    """Run ``df`` through the provided strategy and return the final balance."""
+
+    strategy = strategy or SimpleStrategy()
+    return strategy.generate_signals(df)

--- a/trading_bot/strategies/base.py
+++ b/trading_bot/strategies/base.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+import pandas as pd
+
+
+class Strategy(ABC):
+    """Abstract trading strategy."""
+
+    @abstractmethod
+    def generate_signals(self, df: pd.DataFrame):
+        """Return trading signals or backtest results for the given data."""
+        pass


### PR DESCRIPTION
## Summary
- add abstract `Strategy` base class
- refactor backtester to accept any strategy implementation
- document custom strategy usage
- keep tests passing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860306d0bf8832bb77cb0de22e73710

## Summary by Sourcery

Introduce a Strategy abstraction and refactor the backtester to support pluggable strategies, including an example implementation and updated documentation.

New Features:
- Introduce an abstract Strategy interface for trading logic
- Add a SimpleStrategy implementation replicating the original backtesting logic

Enhancements:
- Refactor backtester to accept pluggable Strategy instances and remove the hardcoded simple_strategy function

Documentation:
- Document how to create and use custom strategy classes in the README