### PR TITLE
Update server port configuration

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -170,3 +170,9 @@ To further enhance the toolkit, the following ideas could be explored:
 - **Multi-Window Trend Alerts**: Notify users when price changes over 1h, 4h, or 24h exceed configurable thresholds.
 - **Trend Dashboard Widgets**: Display sparkline charts summarising short and long term trends.
 - **Historical Trend API**: Provide endpoints to query past trend alerts for backtesting and research.
+
+### Complementary Server Enhancements
+
+- **Configurable Port**: Allow the HTTP server to respect the `PORT` environment variable so deployments can choose a different listening port.
+- **Health Check Endpoint**: Add a simple `/ping` route that returns a 200 status for container orchestrators.
+- **Graceful Shutdown**: Handle SIGTERM and SIGINT signals to close open connections cleanly before exiting.

--- a/crypto-tracker-bot/README.md
+++ b/crypto-tracker-bot/README.md
@@ -25,6 +25,7 @@ Set the following variables in a `.env` file inside `crypto-tracker-bot/`:
 - `STORAGE_INTERVAL` – Interval for persisting price history in milliseconds (optional)
 - `GOOGLE_CLOUD_PROJECT_ID` – Google Cloud project ID used by Vertex AI
 - `GOOGLE_CLOUD_ACCESS_TOKEN` – Access token for the Google Cloud Vertex API
+- `PORT` – Port where the optional server listens (defaults to `3000`)
 
 ## Running the Bot
 
@@ -43,7 +44,7 @@ To start the HTTP server that exposes analysis endpoints, run:
 npm run server
 ```
 
-The server listens on port `3000` by default.
+ The server listens on port `3000` by default. Set the `PORT` environment variable to use a different port.
 
 ## Running Tests
 

--- a/crypto-tracker-bot/server/server.js
+++ b/crypto-tracker-bot/server/server.js
@@ -13,7 +13,7 @@ const apiMonitor = require('../utils/apiMonitor');
 storage.initDatabase();
 
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
 const httpServer = http.createServer(app);
 const io = new Server(httpServer);
 


### PR DESCRIPTION
## Summary
- allow configuring crypto-tracker server port via `PORT`
- document the new `PORT` variable in the bot README
- suggest further server features in `PROPOSALS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686035cb82f0832b8cfadc954ca0b145

## Summary by Sourcery

Enable server port configuration via `PORT` environment variable and update related documentation

Enhancements:
- Allow the HTTP server to use `process.env.PORT` (defaulting to 3000) for its listening port

Documentation:
- Update README to document the `PORT` environment variable and default port
- Add configurable port, health check endpoint, and graceful shutdown proposals to PROPOSALS.md