### PR TITLE
Add simple Telegram trading bot

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -170,3 +170,10 @@ To further enhance the toolkit, the following ideas could be explored:
 - **Multi-Window Trend Alerts**: Notify users when price changes over 1h, 4h, or 24h exceed configurable thresholds.
 - **Trend Dashboard Widgets**: Display sparkline charts summarising short and long term trends.
 - **Historical Trend API**: Provide endpoints to query past trend alerts for backtesting and research.
+
+## Telegram Bot Enhancements
+
+- **Trade History Lookup**: Allow the bot to return recent trades on request.
+- **Custom Order Sizes**: Save preferred trade amounts per symbol for quicker execution.
+- **Backtest Summaries**: Provide a formatted report with key metrics after running `/simulate_backtest`.
+- **Multi-User Support**: Permit multiple authorised user IDs for team-based trading.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ pip install -r requirements.txt
   ./auto_install_and_run.sh
   ```
 
+## Telegram Bot
+
+The dashboard includes a simple Telegram bot. Configure a bot token and the
+allowed user ID then run the script:
+
+```bash
+export TELEGRAM_BOT_TOKEN=YOUR_TOKEN
+export TELEGRAM_USER_ID=123456789
+python trading_bot/telegram_bot.py
+```
+
+Within Telegram you can issue `/buy`, `/sell`, and `/simulate_backtest` commands
+to trigger actions.
+
 ## Running Tests
 
 ### Node Tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn
 streamlit
 plotly
 transformers
+python-telegram-bot

--- a/trading_bot/telegram_bot.py
+++ b/trading_bot/telegram_bot.py
@@ -1,0 +1,61 @@
+import os
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+from .data_fetcher import DataFetcher
+from .indicator_calculator import add_indicators
+from .backtester import backtest
+
+ALLOWED_ID = int(os.getenv("TELEGRAM_USER_ID", "0"))
+
+fetcher = DataFetcher()
+
+async def restrict(update: Update) -> bool:
+    """Return True if the user is authorised."""
+    user_id = update.effective_user.id if update.effective_user else 0
+    if user_id != ALLOWED_ID:
+        if update.message:
+            await update.message.reply_text("Access denied")
+        return False
+    return True
+
+async def buy(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not await restrict(update):
+        return
+    if len(context.args) != 2:
+        await update.message.reply_text("Usage: /buy SYMBOL AMOUNT")
+        return
+    symbol, amount = context.args
+    await update.message.reply_text(f"Buying {amount} of {symbol}")
+
+async def sell(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not await restrict(update):
+        return
+    if len(context.args) != 2:
+        await update.message.reply_text("Usage: /sell SYMBOL AMOUNT")
+        return
+    symbol, amount = context.args
+    await update.message.reply_text(f"Selling {amount} of {symbol}")
+
+async def simulate_backtest(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not await restrict(update):
+        return
+    df = fetcher.get_ohlcv(limit=200)
+    df = add_indicators(df)
+    result = backtest(df)
+    await update.message.reply_text(f"Backtest balance: {result:.2f}")
+
+
+def main() -> None:
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN not set")
+    application = ApplicationBuilder().token(token).build()
+    application.add_handler(CommandHandler("buy", buy))
+    application.add_handler(CommandHandler("sell", sell))
+    application.add_handler(CommandHandler("simulate_backtest", simulate_backtest))
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a Telegram bot using `python-telegram-bot`
- restrict commands to `TELEGRAM_USER_ID`
- add `/buy`, `/sell` and `/simulate_backtest` commands
- document bot setup in README
- list potential Telegram Bot enhancements
- include python-telegram-bot in requirements

## Testing
- `npm test --silent` *(fails: 2 failing tests)*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686035d4f66c832b9a821269708b3f80

## Summary by Sourcery

Add a simple authenticated Telegram trading bot with basic buy, sell, and backtest commands.

New Features:
- Introduce a Telegram bot supporting /buy, /sell, and /simulate_backtest commands restricted by user ID.

Enhancements:
- Outline potential Telegram bot improvements in PROPOSALS.md.

Build:
- Add python-telegram-bot to requirements.txt.

Documentation:
- Add setup and usage instructions for the Telegram trading bot to README.md.