### PR TITLE
Improve README test section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,9 @@ pip install -r requirements.txt
 
 ## Running Tests
 
-### Node Tests
-
-Install dependencies in the bot directory then run the suite:
-## Running Tests
-
 ### Node
-Run all Jest tests from `crypto-tracker-bot`:
+
+Install dependencies in the bot directory then run the Jest suite:
 
 ```bash
 cd crypto-tracker-bot
@@ -62,27 +58,15 @@ npm install
 npm test
 ```
 
-### Python Tests
-
-Before running the Python tests, create and activate a virtual environment then install the requirements:
-```bash
-python -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-```
-After the dependencies are installed, execute the suite:
-
-
-Install the Python requirements and execute the tests from the repository root:
 ### Python
-Run the dashboard tests from the repository root:
+
+Install the Python requirements (a virtual environment is recommended) and run the dashboard tests from the repository root:
 
 ```bash
 pip install -r requirements.txt
-pytest
+PYTHONPATH=. pytest trading_bot/tests
 ```
 
-Both suites should pass once the dependencies are installed.
 Both suites should pass once their dependencies are installed.
 
 ## Directory Overview


### PR DESCRIPTION
## Summary
- clarify how to run the Python test suite

## Testing
- `PYTHONPATH=. pytest trading_bot/tests`

------
https://chatgpt.com/codex/tasks/task_e_686035dc43c4832b917fe31ad0b6bf8e

## Summary by Sourcery

Clarify and consolidate test instructions in README

Documentation:
- Combine and streamline Node test instructions under a single heading
- Update Python test instructions to recommend a virtual environment and include PYTHONPATH with explicit test directory