### PR TITLE
Add monitoring metrics and metrics endpoint

### DIFF
--- a/crypto-tracker-bot/__tests__/metrics.test.js
+++ b/crypto-tracker-bot/__tests__/metrics.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('assert');
+const http = require('http');
+
+const metrics = require('../monitoring/metrics');
+const server = require('../server/server');
+
+async function get(path, port) {
+  return new Promise((resolve, reject) => {
+    http.get({ hostname: 'localhost', port, path }, res => {
+      let data = '';
+      res.on('data', c => data += c);
+      res.on('end', () => resolve({ status: res.statusCode, body: JSON.parse(data) }));
+    }).on('error', reject);
+  });
+}
+
+test('metrics endpoint returns recorded metrics', async () => {
+  metrics.resetMetrics();
+  await new Promise(res => server.start(0, res));
+  const port = server.httpServer.address().port;
+  metrics.recordRequest('testAPI', 50, false);
+  const res = await get('/metrics', port);
+  await new Promise(r => server.close(r));
+  assert.strictEqual(res.status, 200);
+  assert.ok(res.body.testAPI);
+  assert.strictEqual(res.body.testAPI.count, 1);
+});

--- a/crypto-tracker-bot/monitoring/cryptoTracker.js
+++ b/crypto-tracker-bot/monitoring/cryptoTracker.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const config = require('../config');
 const logger = require('../utils/logger');
+const metrics = require('./metrics');
 
 async function fetchPrices() {
   try {
@@ -10,10 +11,15 @@ async function fetchPrices() {
     const prices = {};
 
     for (const coin of coins) {
+      const start = Date.now();
       try {
-        const response = await axios.get(`https://api.polygon.io/v1/last/crypto/${coin}USD?apiKey=${config.polygonApiKey}`);
+        const response = await axios.get(
+          `https://api.polygon.io/v1/last/crypto/${coin}USD?apiKey=${config.polygonApiKey}`
+        );
+        metrics.recordRequest('polygon', Date.now() - start, false);
         prices[coin] = response.data.last.price;
       } catch (err) {
+        metrics.recordRequest('polygon', Date.now() - start, true);
         logger.error(`Error fetching price for ${coin}:`, err);
         prices[coin] = null;
       }

--- a/crypto-tracker-bot/monitoring/metrics.js
+++ b/crypto-tracker-bot/monitoring/metrics.js
@@ -1,0 +1,32 @@
+const metrics = {};
+
+function recordRequest(apiName, durationMs, isError) {
+  if (!metrics[apiName]) {
+    metrics[apiName] = { count: 0, errorCount: 0, totalDuration: 0 };
+  }
+  metrics[apiName].count += 1;
+  metrics[apiName].totalDuration += durationMs;
+  if (isError) {
+    metrics[apiName].errorCount += 1;
+  }
+}
+
+function getMetrics() {
+  const result = {};
+  for (const [name, data] of Object.entries(metrics)) {
+    result[name] = {
+      count: data.count,
+      errorCount: data.errorCount,
+      avgDuration: data.count ? Math.round(data.totalDuration / data.count) : 0
+    };
+  }
+  return result;
+}
+
+function resetMetrics() {
+  for (const key of Object.keys(metrics)) {
+    delete metrics[key];
+  }
+}
+
+module.exports = { recordRequest, getMetrics, resetMetrics };

--- a/crypto-tracker-bot/monitoring/newsAggregator.js
+++ b/crypto-tracker-bot/monitoring/newsAggregator.js
@@ -1,13 +1,16 @@
 const axios = require('axios');
 const config = require('../config');
 const logger = require('../utils/logger');
+const metrics = require('./metrics');
 
 async function fetchTiingoNews() {
+  const start = Date.now();
   try {
     const response = await axios.get('https://api.tiingo.com/tiingo/news', {
       headers: { Authorization: `Token ${config.tiingoApiKey}` },
       params: { tickers: 'BTC,ETH,LTC,DOGE,SHIB', limit: 10 }
     });
+    metrics.recordRequest('Tiingo', Date.now() - start, false);
     return response.data.map(item => ({
       source: 'Tiingo',
       title: item.title,
@@ -15,12 +18,14 @@ async function fetchTiingoNews() {
       publishedAt: new Date(item.publishedAt)
     }));
   } catch (error) {
+    metrics.recordRequest('Tiingo', Date.now() - start, true);
     logger.error('Error fetching Tiingo news:', error);
     return [];
   }
 }
 
 async function fetchNewsAPI() {
+  const start = Date.now();
   try {
     const response = await axios.get('https://newsapi.org/v2/everything', {
       params: {
@@ -31,6 +36,7 @@ async function fetchNewsAPI() {
         sortBy: 'publishedAt'
       }
     });
+    metrics.recordRequest('NewsAPI', Date.now() - start, false);
     return response.data.articles.map(item => ({
       source: 'NewsAPI',
       title: item.title,
@@ -38,16 +44,19 @@ async function fetchNewsAPI() {
       publishedAt: new Date(item.publishedAt)
     }));
   } catch (error) {
+    metrics.recordRequest('NewsAPI', Date.now() - start, true);
     logger.error('Error fetching NewsAPI news:', error);
     return [];
   }
 }
 
 async function fetchCryptoPanickNews() {
+  const start = Date.now();
   try {
     const response = await axios.get('https://cryptopanick.com/api/news', {
       params: { limit: 10, apiKey: config.cryptoPanickApiKey }
     });
+    metrics.recordRequest('CryptoPanick', Date.now() - start, false);
     return response.data.articles.map(item => ({
       source: 'CryptoPanick',
       title: item.title,
@@ -55,16 +64,19 @@ async function fetchCryptoPanickNews() {
       publishedAt: new Date(item.publishedAt)
     }));
   } catch (error) {
+    metrics.recordRequest('CryptoPanick', Date.now() - start, true);
     logger.error('Error fetching CryptoPanick news:', error);
     return [];
   }
 }
 
 async function fetchMarketeuxNews() {
+  const start = Date.now();
   try {
     const response = await axios.get('https://api.marketeux.com/news', {
       params: { limit: 10, apiKey: config.marketeuxApiKey }
     });
+    metrics.recordRequest('Marketeux', Date.now() - start, false);
     return response.data.articles.map(item => ({
       source: 'Marketeux',
       title: item.title,
@@ -72,12 +84,14 @@ async function fetchMarketeuxNews() {
       publishedAt: new Date(item.publishedAt)
     }));
   } catch (error) {
+    metrics.recordRequest('Marketeux', Date.now() - start, true);
     logger.error('Error fetching Marketeux news:', error);
     return [];
   }
 }
 
 async function fetchAlphaVantageNews() {
+  const start = Date.now();
   try {
     const response = await axios.get('https://www.alphavantage.co/query', {
       params: {
@@ -86,6 +100,7 @@ async function fetchAlphaVantageNews() {
         apikey: config.alphaVantageApiKey
       }
     });
+    metrics.recordRequest('AlphaVantage', Date.now() - start, false);
     return response.data.feed.map(item => ({
       source: 'AlphaVantage',
       title: item.title,
@@ -93,14 +108,17 @@ async function fetchAlphaVantageNews() {
       publishedAt: new Date(item.time_published * 1000)
     }));
   } catch (error) {
+    metrics.recordRequest('AlphaVantage', Date.now() - start, true);
     logger.error('Error fetching AlphaVantage news:', error);
     return [];
   }
 }
 
 async function fetchCoinGeckoNews() {
+  const start = Date.now();
   try {
     const response = await axios.get('https://api.coingecko.com/api/v3/news');
+    metrics.recordRequest('CoinGecko', Date.now() - start, false);
     return response.data.data.map(item => ({
       source: 'CoinGecko',
       title: item.title,
@@ -108,6 +126,7 @@ async function fetchCoinGeckoNews() {
       publishedAt: new Date(item.date)
     }));
   } catch (error) {
+    metrics.recordRequest('CoinGecko', Date.now() - start, true);
     logger.error('Error fetching CoinGecko news:', error);
     return [];
   }

--- a/crypto-tracker-bot/monitoring/newsTracker.js
+++ b/crypto-tracker-bot/monitoring/newsTracker.js
@@ -1,12 +1,18 @@
 const axios = require('axios');
 const config = require('../config');
 const logger = require('../utils/logger');
+const metrics = require('./metrics');
 
 async function fetchNews() {
+  const start = Date.now();
   try {
-    const response = await axios.get(`https://newsapi.org/v2/everything?q=cryptocurrency&apiKey=${config.newsApiKey}`);
+    const response = await axios.get(
+      `https://newsapi.org/v2/everything?q=cryptocurrency&apiKey=${config.newsApiKey}`
+    );
+    metrics.recordRequest('NewsAPI', Date.now() - start, false);
     return response.data.articles;
   } catch (error) {
+    metrics.recordRequest('NewsAPI', Date.now() - start, true);
     logger.error("Error fetching news:", error);
     throw error;
   }

--- a/crypto-tracker-bot/server/server.js
+++ b/crypto-tracker-bot/server/server.js
@@ -8,12 +8,13 @@ const imageAnalysis = require('../technicalIndicators/imageAnalysis');
 const storage = require('../persist/storage');
 const logger = require('../utils/logger');
 const apiMonitor = require('../utils/apiMonitor');
+const metrics = require('../monitoring/metrics');
 
 // initialize sqlite database
 storage.initDatabase();
 
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
 const httpServer = http.createServer(app);
 const io = new Server(httpServer);
 
@@ -154,8 +155,12 @@ app.get('/api/health', (req, res) => {
   res.json(apiMonitor.getMetrics());
 });
 
+app.get('/metrics', (req, res) => {
+  res.json(metrics.getMetrics());
+});
+
 // Emit latest prices to connected clients every 10 seconds
-setInterval(() => {
+const priceInterval = setInterval(() => {
   try {
     const latest = storage.getLatestPrice();
     if (latest) {
@@ -166,6 +171,19 @@ setInterval(() => {
   }
 }, 10000);
 
-httpServer.listen(port, () => {
-  console.log(`Server is listening at http://localhost:${port}`);
-});
+function start(p = port, cb) {
+  httpServer.listen(p, cb);
+}
+
+function close(cb) {
+  clearInterval(priceInterval);
+  httpServer.close(cb);
+}
+
+if (require.main === module) {
+  start(port, () => {
+    console.log(`Server is listening at http://localhost:${port}`);
+  });
+}
+
+module.exports = { app, httpServer, start, close };


### PR DESCRIPTION
## Summary
- track API request durations and errors in new `monitoring/metrics.js`
- measure API calls in crypto/news trackers and aggregator
- expose metrics at `/metrics` in the server
- export server start/close helpers for tests
- test metrics endpoint via new unit test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686035e339bc832b86ce44dff3eb4228

## Summary by Sourcery

Introduce a metrics system to record external API call counts, durations, and errors, instrument existing trackers to capture these metrics, expose them via a new /metrics endpoint, and provide test utilities and a unit test for the metrics endpoint.

New Features:
- Expose collected API metrics at a new /metrics endpoint

Enhancements:
- Introduce a metrics module to record API request counts, durations, and errors
- Instrument crypto price and news fetchers to record request metrics
- Export server start/close helpers for testing

Tests:
- Add a unit test verifying the /metrics endpoint returns recorded metrics