### PR TITLE
Add real-time Socket.IO price streaming

### DIFF
--- a/crypto-tracker-bot/client/live-prices.html
+++ b/crypto-tracker-bot/client/live-prices.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Live Price Demo</title>
+</head>
+<body>
+  <h1>Live Prices</h1>
+  <pre id="prices">Connecting...</pre>
+  <script src="/socket.io/socket.io.js"></script>
+  <script>
+    const output = document.getElementById('prices');
+    const socket = io();
+    socket.on('prices', payload => {
+      const data = payload.data || payload;
+      output.textContent = JSON.stringify(data, null, 2);
+    });
+  </script>
+</body>
+</html>

--- a/crypto-tracker-bot/package-lock.json
+++ b/crypto-tracker-bot/package-lock.json
@@ -16,8 +16,7 @@
         "node-schedule": "^2.1.1",
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",

--- a/crypto-tracker-bot/persist/storage.js
+++ b/crypto-tracker-bot/persist/storage.js
@@ -1,6 +1,9 @@
 const path = require('path');
 const Database = require('better-sqlite3');
+const EventEmitter = require('events');
 const logger = require('../utils/logger');
+
+const emitter = new EventEmitter();
 
 let db;
 
@@ -22,6 +25,7 @@ function insertPriceHistory(prices) {
     const database = initDatabase();
     const stmt = database.prepare('INSERT INTO price_history (timestamp, prices) VALUES (?, ?)');
     stmt.run(new Date().toISOString(), JSON.stringify(prices));
+    emitter.emit('insert', prices);
   } catch (error) {
     logger.error('Failed to insert price history:', error);
     throw error;
@@ -70,4 +74,5 @@ module.exports = {
   getPriceHistory,
   getLatestPrice,
   getPriceBefore,
+  emitter,
 };

--- a/crypto-tracker-bot/server/server.js
+++ b/crypto-tracker-bot/server/server.js
@@ -22,6 +22,15 @@ io.on('connection', () => {
   logger.info('Socket.IO client connected');
 });
 
+// Forward new price inserts to all clients in real time
+storage.emitter.on('insert', (prices) => {
+  try {
+    io.emit('prices', { data: prices });
+  } catch (error) {
+    logger.error('Error emitting prices from storage:', error);
+  }
+});
+
 // Multer setup for image uploads
 // Ensure uploads directory exists
 fs.mkdirSync('uploads', { recursive: true });


### PR DESCRIPTION
## Summary
- stream price updates from storage using an event emitter
- broadcast inserts via Socket.IO server
- install Socket.IO packages and update lockfile
- add a simple live-prices client example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68603e66fb5c832bace44e4746b3230c

## Summary by Sourcery

Integrate real-time price streaming by emitting database insert events through Socket.IO and providing a live-prices HTML client demo.

New Features:
- Emit real-time price updates to all connected clients via Socket.IO on database insert events.
- Expose an EventEmitter in storage to broadcast price insertions.
- Add a simple live-prices HTML client that connects to Socket.IO and displays incoming price data.

Build:
- Update package-lock.json to include Socket.IO dependencies.