### PR TITLE
Add reporting features to Python backtester

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ pandas_ta
 scikit-learn
 streamlit
 plotly
+matplotlib
 transformers
 python-telegram-bot

--- a/trading_bot/app.py
+++ b/trading_bot/app.py
@@ -32,8 +32,13 @@ data = load_data()
 current_price = fetcher.get_current_price(symbol)
 
 if run_backtest:
-    result = backtest(data)
-    st.sidebar.write(f"Backtest balance: {result:.2f}")
+    report = backtest(data, report_dir="trading_bot/reports")
+    st.sidebar.write(f"Backtest balance: {report.final_balance:.2f}")
+    st.sidebar.write(f"Profit: {report.profit:.2f}")
+    st.sidebar.write(f"Max DD: {report.max_drawdown:.2%}")
+    st.sidebar.write(f"Trades: {report.num_trades}")
+    if report.figure_path:
+        st.image(report.figure_path)
 
 sentiment_score = analyze_sentiment([])
 model_prob = model.predict(data)

--- a/trading_bot/backtester.py
+++ b/trading_bot/backtester.py
@@ -1,4 +1,9 @@
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
+
+import json
+import matplotlib.pyplot as plt
 
 import pandas as pd
 
@@ -8,23 +13,85 @@ from trading_bot.strategies.base import Strategy
 class SimpleStrategy(Strategy):
     """Reimplements the original hard-coded logic as a strategy class."""
 
-    def generate_signals(self, df: pd.DataFrame) -> float:
-        position = 0
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        position = 0.0
         balance = 1.0
+        equity = []
         for _, row in df.iterrows():
-            if row['close'] > row['vwap'] and row['rsi'] < 30 and position == 0:
-                position = balance / row['close']
-                balance = 0
-            elif position and (row['close'] < row['vwap'] or row['rsi'] > 70):
-                balance = position * row['close']
-                position = 0
+            if row["close"] > row["vwap"] and row["rsi"] < 30 and position == 0:
+                position = balance / row["close"]
+                balance = 0.0
+            elif position and (row["close"] < row["vwap"] or row["rsi"] > 70):
+                balance = position * row["close"]
+                position = 0.0
+            equity.append(balance + position * row["close"])
         if position:
-            balance = position * df.iloc[-1]['close']
-        return balance
+            balance = position * df.iloc[-1]["close"]
+            equity[-1] = balance
+        return pd.Series(equity, index=df.index[: len(equity)])
 
 
-def backtest(df: pd.DataFrame, strategy: Optional[Strategy] = None) -> float:
-    """Run ``df`` through the provided strategy and return the final balance."""
+@dataclass
+class BacktestReport:
+    final_balance: float
+    profit: float
+    max_drawdown: float
+    num_trades: int
+    equity_curve: pd.Series
+    stats_path: Optional[str] = None
+    figure_path: Optional[str] = None
+
+
+def backtest(
+    df: pd.DataFrame, strategy: Optional[Strategy] = None, report_dir: Optional[str] = None
+) -> BacktestReport:
+    """Run ``df`` through the provided strategy and optionally save a report."""
 
     strategy = strategy or SimpleStrategy()
-    return strategy.generate_signals(df)
+    equity_curve = strategy.generate_signals(df)
+
+    final_balance = float(equity_curve.iloc[-1])
+    profit = final_balance - 1.0
+    running_max = equity_curve.cummax()
+    drawdowns = (equity_curve - running_max) / running_max
+    max_drawdown = float(drawdowns.min()) if not drawdowns.empty else 0.0
+
+    # Count trades as number of changes in position
+    num_trades = int((equity_curve.diff() != 0).sum())
+
+    stats_path = None
+    figure_path = None
+    if report_dir:
+        report_dir_path = Path(report_dir)
+        report_dir_path.mkdir(parents=True, exist_ok=True)
+        stats_path = str(report_dir_path / "stats.json")
+        with open(stats_path, "w") as f:
+            json.dump(
+                {
+                    "final_balance": final_balance,
+                    "profit": profit,
+                    "max_drawdown": max_drawdown,
+                    "num_trades": num_trades,
+                },
+                f,
+            )
+
+        figure_path = str(report_dir_path / "equity_curve.png")
+        fig, ax = plt.subplots()
+        equity_curve.plot(ax=ax)
+        ax.set_title("Equity Curve")
+        ax.set_xlabel("Step")
+        ax.set_ylabel("Balance")
+        fig.tight_layout()
+        fig.savefig(figure_path)
+        plt.close(fig)
+
+    return BacktestReport(
+        final_balance=final_balance,
+        profit=profit,
+        max_drawdown=max_drawdown,
+        num_trades=num_trades,
+        equity_curve=equity_curve,
+        stats_path=stats_path,
+        figure_path=figure_path,
+    )

--- a/trading_bot/tests/test_backtester.py
+++ b/trading_bot/tests/test_backtester.py
@@ -10,11 +10,22 @@ import pandas as pd
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 from trading_bot.backtester import backtest
 
-def test_backtest_returns_balance():
+def test_backtest_returns_report():
     df = pd.DataFrame({
         'vwap': [0.9, 0.95, 1.0],
         'rsi': [20, 40, 20],
         'close': [1.0, 1.1, 1.2]
     })
-    result = backtest(df)
-    assert result > 1.0
+    report = backtest(df)
+    assert report.final_balance > 1.0
+
+
+def test_backtest_creates_report_files(tmp_path):
+    df = pd.DataFrame({
+        'vwap': [0.9, 0.95, 1.0],
+        'rsi': [20, 40, 20],
+        'close': [1.0, 1.1, 1.2]
+    })
+    report = backtest(df, report_dir=tmp_path)
+    assert (tmp_path / 'stats.json').exists()
+    assert (tmp_path / 'equity_curve.png').exists()


### PR DESCRIPTION
## Summary
- extend backtester to calculate profit, max drawdown and number of trades
- produce equity-curve figure and save JSON/PNG report files
- display those stats and the chart in `app.py`
- add unit tests verifying report files are written
- include matplotlib in requirements

## Testing
- `pip install matplotlib`
- `PYTHONPATH=. pytest -q trading_bot/tests`

------
https://chatgpt.com/codex/tasks/task_e_68603e6e92d8832ba28d8c1ff3f7ed93

## Summary by Sourcery

Extend the Python backtester to produce a detailed report with key performance metrics and an equity-curve plot, persist those results to JSON/PNG files, update the Streamlit app to display the new metrics, and add corresponding tests and dependencies.

New Features:
- Extend backtester to return a comprehensive BacktestReport with profit, max drawdown, trade count, and equity curve
- Support optional saving of backtest stats as JSON and equity curve as PNG in a specified report directory
- Display backtest metrics and equity curve image in the Streamlit app sidebar

Enhancements:
- Refactor Strategy.generate_signals to output an equity curve series instead of final balance
- Add matplotlib to project dependencies for plotting

Tests:
- Add unit tests to verify BacktestReport structure and report file creation