### PR TITLE
Add Strategy Explorer page

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -196,3 +196,9 @@ To further enhance the toolkit, the following ideas could be explored:
 - **Health Check Endpoint**: Add a simple `/ping` route that returns a 200 status for container orchestrators.
 - **Graceful Shutdown**: Handle SIGTERM and SIGINT signals to close open connections cleanly before exiting.
 
+
+### Additional Feature Proposals
+
+- **Feature Importance Charts**: Visualize which indicators contribute most to a model's predictions.
+- **Hyperparameter Tuning Tools**: Provide automated search over model parameters with cross-validation.
+- **Result Persistence**: Save backtest and model evaluation results to a local database for later comparison.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pip install -r requirements.txt
 - `npm run server` – launch the optional analysis server
 - `auto_install_and_run.sh` – install Node modules and run both the bot and server
 - `streamlit run trading_bot/app.py` – start the trading dashboard
+- `streamlit run trading_bot/strategy_explorer.py` – explore ML models on historical data
 
 ## Running
 
@@ -40,6 +41,10 @@ pip install -r requirements.txt
 - **Run the trading dashboard:**
   ```bash
   streamlit run trading_bot/app.py
+  ```
+- **Run the strategy explorer:**
+  ```bash
+  streamlit run trading_bot/strategy_explorer.py
   ```
 - **Quick start both bot and server:**
   ```bash

--- a/trading_bot/strategy_explorer.py
+++ b/trading_bot/strategy_explorer.py
@@ -1,0 +1,52 @@
+import streamlit as st
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score, TimeSeriesSplit
+from sklearn.preprocessing import StandardScaler
+from sklearn.pipeline import Pipeline
+
+from data_fetcher import DataFetcher
+from indicator_calculator import add_indicators
+
+st.set_page_config(page_title="Strategy Explorer")
+
+st.title("ML Strategy Explorer")
+
+symbol = st.sidebar.text_input("Trading Pair", value="BTC/USDT")
+timeframe = st.sidebar.text_input("Timeframe", value="1h")
+model_name = st.sidebar.selectbox(
+    "Model", ["Logistic Regression", "Random Forest"]
+)
+splits = st.sidebar.slider(
+    "Cross-Validation Splits", min_value=2, max_value=10, value=5
+)
+
+@st.cache_data(ttl=3600)
+def load_data(sym: str, tf: str) -> pd.DataFrame:
+    fetcher = DataFetcher()
+    df = fetcher.get_ohlcv(symbol=sym, timeframe=tf, limit=1000)
+    df = add_indicators(df)
+    df.dropna(inplace=True)
+    return df
+
+df = load_data(symbol, timeframe)
+X = df[["rsi", "ema", "adx"]]
+y = (df["close"].shift(-1) > df["close"]).astype(int)
+X = X[:-1]
+y = y[:-1]
+
+if model_name == "Logistic Regression":
+    model = Pipeline([
+        ("scaler", StandardScaler()),
+        ("clf", LogisticRegression(max_iter=200)),
+    ])
+else:
+    model = RandomForestClassifier(n_estimators=100, random_state=42)
+
+cv = TimeSeriesSplit(n_splits=splits)
+scores = cross_val_score(model, X, y, cv=cv, scoring="accuracy")
+
+st.write(f"Mean accuracy: {scores.mean():.3f} ± {scores.std():.3f}")
+
+st.line_chart(pd.Series(scores, name="Accuracy"))


### PR DESCRIPTION
## Summary
- add `strategy_explorer.py` Streamlit page for experimenting with ML models
- document how to launch the page in the README
- propose new complementary features in PROPOSALS

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603e7874e0832ba175ba313d14aff3

## Summary by Sourcery

Introduce a new Streamlit-based Strategy Explorer page to enable interactive ML model experimentation on historical trading data, update related documentation, and expand future feature proposals.

New Features:
- Add Streamlit Strategy Explorer page with configurable trading pair, timeframe, model selection, and cross-validated accuracy visualization.

Documentation:
- Update README to include instructions for running the Strategy Explorer page.
- Extend PROPOSALS.md with additional feature ideas such as feature importance charts, hyperparameter tuning tools, and result persistence.