### PR TITLE
Add volatility-based risk management

### DIFF
--- a/trading_bot/backtester.py
+++ b/trading_bot/backtester.py
@@ -3,21 +3,32 @@ from typing import Optional
 import pandas as pd
 
 from trading_bot.strategies.base import Strategy
+from trading_bot.risk import add_stop_levels
 
 
 class SimpleStrategy(Strategy):
     """Reimplements the original hard-coded logic as a strategy class."""
 
     def generate_signals(self, df: pd.DataFrame) -> float:
+        df = add_stop_levels(df)
         position = 0
         balance = 1.0
+        stop_loss = None
+        take_profit = None
         for _, row in df.iterrows():
-            if row['close'] > row['vwap'] and row['rsi'] < 30 and position == 0:
-                position = balance / row['close']
-                balance = 0
-            elif position and (row['close'] < row['vwap'] or row['rsi'] > 70):
-                balance = position * row['close']
-                position = 0
+            if position == 0:
+                if row['close'] > row['vwap'] and row['rsi'] < 30:
+                    position = balance / row['close']
+                    balance = 0
+                    stop_loss = row['stop_loss']
+                    take_profit = row['take_profit']
+            else:
+                if row['close'] <= stop_loss or row['close'] >= take_profit:
+                    balance = position * row['close']
+                    position = 0
+                elif row['close'] < row['vwap'] or row['rsi'] > 70:
+                    balance = position * row['close']
+                    position = 0
         if position:
             balance = position * df.iloc[-1]['close']
         return balance

--- a/trading_bot/risk.py
+++ b/trading_bot/risk.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+
+def add_stop_levels(
+    df: pd.DataFrame,
+    window: int = 14,
+    stop_mult: float = 1.5,
+    take_mult: float = 3.0,
+) -> pd.DataFrame:
+    """Return a DataFrame with dynamic stop-loss and take-profit levels.
+
+    Volatility is estimated using the rolling mean of absolute price changes.
+    """
+    df = df.copy()
+    vol = df["close"].diff().abs().rolling(window).mean()
+    vol.fillna(method="bfill", inplace=True)
+    df["stop_loss"] = df["close"] - vol * stop_mult
+    df["take_profit"] = df["close"] + vol * take_mult
+    return df

--- a/trading_bot/tests/test_backtester.py
+++ b/trading_bot/tests/test_backtester.py
@@ -18,3 +18,15 @@ def test_backtest_returns_balance():
     })
     result = backtest(df)
     assert result > 1.0
+
+
+def test_stop_loss_triggered():
+    df = pd.DataFrame({
+        'vwap': [0.9, 0.9, 0.9],
+        'rsi': [20, 40, 40],
+        'close': [1.0, 1.05, 0.8],
+        'high': [1.1, 1.1, 1.05],
+        'low': [0.9, 1.0, 0.75]
+    })
+    result = backtest(df)
+    assert result < 1.0


### PR DESCRIPTION
## Summary
- introduce `risk.py` for stop-loss and take-profit based on volatility
- integrate risk management into backtester
- verify stop-loss behaviour with a new unit test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603e7f7414832b9e9317f50507214d

## Summary by Sourcery

Introduce volatility-based risk management by computing dynamic stop-loss and take-profit levels and integrating them into the backtester’s signal logic, with accompanying unit test coverage.

New Features:
- Compute dynamic stop-loss and take-profit thresholds based on rolling volatility in a new risk module
- Integrate volatility-based stop levels into the backtester to exit positions on stop-loss or take-profit

Tests:
- Add a unit test to verify that the stop-loss level correctly triggers and reduces the backtest balance