### PR TITLE
Add Strategy Explorer result tracking

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -196,3 +196,10 @@ To further enhance the toolkit, the following ideas could be explored:
 - **Health Check Endpoint**: Add a simple `/ping` route that returns a 200 status for container orchestrators.
 - **Graceful Shutdown**: Handle SIGTERM and SIGINT signals to close open connections cleanly before exiting.
 
+
+### Additional Feature Proposals
+
+- **Feature Importance Charts**: Visualize which indicators contribute most to a model's predictions.
+- **Hyperparameter Tuning Tools**: Provide automated search over model parameters with cross-validation.
+- **Result Persistence**: Save backtest and model evaluation results to a local database for later comparison.
+- **Scheduled Model Retraining**: Periodically refresh saved models with the latest price data and append new evaluations to the history.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pip install -r requirements.txt
 - `npm run server` – launch the optional analysis server
 - `auto_install_and_run.sh` – install Node modules and run both the bot and server
 - `streamlit run trading_bot/app.py` – start the trading dashboard
+- `streamlit run trading_bot/strategy_explorer.py` – explore ML models on historical data
 
 ## Running
 
@@ -41,6 +42,12 @@ pip install -r requirements.txt
   ```bash
   streamlit run trading_bot/app.py
   ```
+- **Run the strategy explorer:**
+  ```bash
+  streamlit run trading_bot/strategy_explorer.py
+  ```
+  This page supports hyperparameter tuning, feature-importance charts,
+  and persists evaluation results for later review.
 - **Quick start both bot and server:**
   ```bash
   ./auto_install_and_run.sh

--- a/trading_bot/results_db.py
+++ b/trading_bot/results_db.py
@@ -1,0 +1,100 @@
+import sqlite3
+import json
+import os
+from typing import Dict, Iterable
+from statistics import mean, pstdev
+
+DB_PATH = os.path.join(os.path.dirname(__file__), "results.db")
+
+
+def init_db() -> None:
+    """Ensure the SQLite database and tables exist."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS evaluations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            symbol TEXT,
+            timeframe TEXT,
+            model TEXT,
+            params TEXT,
+            mean_accuracy REAL,
+            std_accuracy REAL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS feature_importance (
+            evaluation_id INTEGER,
+            feature TEXT,
+            importance REAL,
+            FOREIGN KEY(evaluation_id) REFERENCES evaluations(id)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_evaluation(
+    symbol: str,
+    timeframe: str,
+    model: str,
+    params: Dict[str, object],
+    scores: Iterable[float],
+    importance: Dict[str, float],
+) -> None:
+    """Persist evaluation metrics and feature importances."""
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    scores = list(scores)
+    cur.execute(
+        "INSERT INTO evaluations (symbol, timeframe, model, params, mean_accuracy, std_accuracy) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            symbol,
+            timeframe,
+            model,
+            json.dumps(params),
+            float(mean(scores)) if scores else 0.0,
+            float(pstdev(scores)) if len(scores) > 1 else 0.0,
+        ),
+    )
+    eval_id = cur.lastrowid
+    for feat, imp in importance.items():
+        cur.execute(
+            "INSERT INTO feature_importance (evaluation_id, feature, importance) VALUES (?, ?, ?)",
+            (eval_id, feat, float(imp)),
+        )
+    conn.commit()
+    conn.close()
+
+
+def load_evaluations(limit: int = 20):
+    """Return recent evaluations as a list of dicts."""
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, timestamp, symbol, timeframe, model, params, mean_accuracy, std_accuracy FROM evaluations ORDER BY timestamp DESC LIMIT ?",
+        (limit,),
+    )
+    rows = cur.fetchall()
+    conn.close()
+    records = []
+    for r in rows:
+        record = {
+            "id": r[0],
+            "timestamp": r[1],
+            "symbol": r[2],
+            "timeframe": r[3],
+            "model": r[4],
+            "params": json.loads(r[5]) if r[5] else {},
+            "mean_accuracy": r[6],
+            "std_accuracy": r[7],
+        }
+        records.append(record)
+    return records

--- a/trading_bot/strategy_explorer.py
+++ b/trading_bot/strategy_explorer.py
@@ -1,0 +1,84 @@
+import streamlit as st
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score, TimeSeriesSplit, GridSearchCV
+from sklearn.preprocessing import StandardScaler
+from sklearn.pipeline import Pipeline
+import plotly.express as px
+
+from data_fetcher import DataFetcher
+from indicator_calculator import add_indicators
+from results_db import save_evaluation, load_evaluations
+
+st.set_page_config(page_title="Strategy Explorer")
+
+st.title("ML Strategy Explorer")
+
+symbol = st.sidebar.text_input("Trading Pair", value="BTC/USDT")
+timeframe = st.sidebar.text_input("Timeframe", value="1h")
+model_name = st.sidebar.selectbox(
+    "Model", ["Logistic Regression", "Random Forest"]
+)
+splits = st.sidebar.slider(
+    "Cross-Validation Splits", min_value=2, max_value=10, value=5
+)
+perform_tuning = st.sidebar.checkbox("Hyperparameter Tuning")
+
+@st.cache_data(ttl=3600)
+def load_data(sym: str, tf: str) -> pd.DataFrame:
+    fetcher = DataFetcher()
+    df = fetcher.get_ohlcv(symbol=sym, timeframe=tf, limit=1000)
+    df = add_indicators(df)
+    df.dropna(inplace=True)
+    return df
+
+df = load_data(symbol, timeframe)
+X = df[["rsi", "ema", "adx"]]
+y = (df["close"].shift(-1) > df["close"]).astype(int)
+X = X[:-1]
+y = y[:-1]
+
+if model_name == "Logistic Regression":
+    base_model = Pipeline([
+        ("scaler", StandardScaler()),
+        ("clf", LogisticRegression(max_iter=200)),
+    ])
+    param_grid = {"clf__C": [0.01, 0.1, 1.0, 10.0]}
+else:
+    base_model = RandomForestClassifier(n_estimators=100, random_state=42)
+    param_grid = {"n_estimators": [100, 200], "max_depth": [None, 5, 10]}
+
+cv = TimeSeriesSplit(n_splits=splits)
+
+if perform_tuning:
+    search = GridSearchCV(base_model, param_grid, cv=cv, scoring="accuracy")
+    search.fit(X, y)
+    model = search.best_estimator_
+    params = search.best_params_
+else:
+    model = base_model
+    params = {}
+
+scores = cross_val_score(model, X, y, cv=cv, scoring="accuracy")
+model.fit(X, y)
+
+if model_name == "Logistic Regression":
+    coef = model.named_steps["clf"].coef_[0]
+    importance = dict(zip(["rsi", "ema", "adx"], coef))
+else:
+    importance = dict(zip(["rsi", "ema", "adx"], model.feature_importances_))
+
+save_evaluation(symbol, timeframe, model_name, params, scores, importance)
+
+st.write(f"Mean accuracy: {scores.mean():.3f} ± {scores.std():.3f}")
+
+st.line_chart(pd.Series(scores, name="Accuracy"))
+
+fig = px.bar(x=list(importance.keys()), y=list(importance.values()), labels={"x": "Feature", "y": "Importance"}, title="Feature Importance")
+st.plotly_chart(fig, use_container_width=True)
+
+st.subheader("Saved Evaluations")
+history = pd.DataFrame(load_evaluations())
+if not history.empty:
+    st.dataframe(history)


### PR DESCRIPTION
## Summary
- expand the strategy explorer with optional hyperparameter tuning
- visualize feature importance and show saved evaluations
- persist evaluation results in a new SQLite database module
- document the updated explorer capabilities in the README
- propose scheduled model retraining in PROPOSALS

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68603e7874e0832ba175ba313d14aff3

## Summary by Sourcery

Introduce a new Strategy Explorer app that supports hyperparameter tuning, feature importance visualization, and persistent tracking of evaluation results in SQLite, and update documentation and proposals to reflect these additions.

New Features:
- Add a Streamlit-based Strategy Explorer for ML models on historical data
- Enable optional hyperparameter tuning for model parameters
- Visualize feature importance charts for model indicators
- Persist evaluation metrics and feature importances to a local SQLite database
- Show a history of saved evaluation results in the explorer

Documentation:
- Update README with instructions and capabilities for the new strategy explorer
- Extend PROPOSALS.md with feature importance, hyperparameter tuning, result persistence, and scheduled retraining ideas