### PR TITLE
Add multi-asset charts

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -196,3 +196,8 @@ To further enhance the toolkit, the following ideas could be explored:
 - **Health Check Endpoint**: Add a simple `/ping` route that returns a 200 status for container orchestrators.
 - **Graceful Shutdown**: Handle SIGTERM and SIGINT signals to close open connections cleanly before exiting.
 
+### Dashboard Multi-Asset View
+
+- **Tabbed Charts**: Display multiple trading pairs at once using tabs to quickly compare assets.
+- **Cached Indicator Data**: Reuse indicator calculations between refreshes to minimise API usage.
+

--- a/trading_bot/app.py
+++ b/trading_bot/app.py
@@ -12,51 +12,88 @@ st.set_page_config(page_title="Crypto Dashboard", layout="wide")
 fetcher = DataFetcher()
 model = PriceDirectionModel()
 
-symbol = st.sidebar.text_input("Trading Pair", value="BTC/USDT")
+symbols_input = st.sidebar.text_input(
+    "Trading Pairs (comma separated)", value="BTC/USDT"
+)
+symbols = [s.strip().upper() for s in symbols_input.split(",") if s.strip()]
 refresh = st.sidebar.number_input("Refresh (s)", min_value=5, value=30)
 run_backtest = st.sidebar.button("Run Backtest")
 refresh_btn = st.sidebar.button("Refresh Now")
 
 @st.cache_data(ttl=60)
-def load_data():
-    df = fetcher.get_ohlcv(symbol, timeframe="1m", limit=500)
+def load_data(sym: str):
+    df = fetcher.get_ohlcv(sym, timeframe="1m", limit=500)
     df = add_indicators(df)
     df = find_fractals(df)
     lows, highs = support_resistance(df)
-    df['support'] = lows
-    df['resistance'] = highs
+    df["support"] = lows
+    df["resistance"] = highs
     model.train(df)
     return df
 
-data = load_data()
-current_price = fetcher.get_current_price(symbol)
+tabs = st.tabs(symbols)
 
-if run_backtest:
-    result = backtest(data)
-    st.sidebar.write(f"Backtest balance: {result:.2f}")
+for sym, tab in zip(symbols, tabs):
+    with tab:
+        data = load_data(sym)
+        current_price = fetcher.get_current_price(sym)
 
-sentiment_score = analyze_sentiment([])
-model_prob = model.predict(data)
+        if run_backtest:
+            result = backtest(data)
+            st.write(f"Backtest balance: {result:.2f}")
 
-st.metric("Current Price", current_price)
-fig = go.Figure(data=[go.Candlestick(x=data['timestamp'],
-                open=data['open'], high=data['high'],
-                low=data['low'], close=data['close'])])
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['vwap'], name='VWAP'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['ema'], name='EMA'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['sma'], name='SMA'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['support'], name='Support', line=dict(dash='dot')))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['resistance'], name='Resistance', line=dict(dash='dot')))
-fractals_up = data[data['fractal_up']]
-fractals_down = data[data['fractal_down']]
-fig.add_trace(go.Scatter(x=fractals_up['timestamp'], y=fractals_up['high'], mode='markers', marker_symbol='triangle-up', marker_color='green', name='Fractal Up'))
-fig.add_trace(go.Scatter(x=fractals_down['timestamp'], y=fractals_down['low'], mode='markers', marker_symbol='triangle-down', marker_color='red', name='Fractal Down'))
+        sentiment_score = analyze_sentiment([])
+        model_prob = model.predict(data)
 
-st.plotly_chart(fig, use_container_width=True)
+        st.metric("Current Price", current_price)
+        fig = go.Figure(
+            data=[
+                go.Candlestick(
+                    x=data["timestamp"],
+                    open=data["open"],
+                    high=data["high"],
+                    low=data["low"],
+                    close=data["close"],
+                )
+            ]
+        )
+        fig.add_trace(go.Scatter(x=data["timestamp"], y=data["vwap"], name="VWAP"))
+        fig.add_trace(go.Scatter(x=data["timestamp"], y=data["ema"], name="EMA"))
+        fig.add_trace(go.Scatter(x=data["timestamp"], y=data["sma"], name="SMA"))
+        fig.add_trace(
+            go.Scatter(x=data["timestamp"], y=data["support"], name="Support", line=dict(dash="dot"))
+        )
+        fig.add_trace(
+            go.Scatter(x=data["timestamp"], y=data["resistance"], name="Resistance", line=dict(dash="dot"))
+        )
+        fractals_up = data[data["fractal_up"]]
+        fractals_down = data[data["fractal_down"]]
+        fig.add_trace(
+            go.Scatter(
+                x=fractals_up["timestamp"],
+                y=fractals_up["high"],
+                mode="markers",
+                marker_symbol="triangle-up",
+                marker_color="green",
+                name="Fractal Up",
+            )
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=fractals_down["timestamp"],
+                y=fractals_down["low"],
+                mode="markers",
+                marker_symbol="triangle-down",
+                marker_color="red",
+                name="Fractal Down",
+            )
+        )
 
-col1, col2 = st.columns(2)
-col1.write(f"Sentiment score: {sentiment_score}")
-col2.write(f"Model long probability: {model_prob}")
+        st.plotly_chart(fig, use_container_width=True)
+
+        col1, col2 = st.columns(2)
+        col1.write(f"Sentiment score: {sentiment_score}")
+        col2.write(f"Model long probability: {model_prob}")
 
 if refresh_btn:
     st.experimental_rerun()

--- a/trading_bot/data_fetcher.py
+++ b/trading_bot/data_fetcher.py
@@ -24,3 +24,12 @@ class DataFetcher:
         )
         df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
         return df
+
+    def get_ohlcv_multi(
+        self, symbols: list[str], timeframe: str = "1m", limit: int = 200
+    ) -> dict[str, pd.DataFrame]:
+        """Fetch OHLCV data for multiple symbols."""
+        data = {}
+        for sym in symbols:
+            data[sym] = self.get_ohlcv(sym, timeframe=timeframe, limit=limit)
+        return data

--- a/trading_bot/tests/test_data_fetcher.py
+++ b/trading_bot/tests/test_data_fetcher.py
@@ -21,6 +21,20 @@ def test_get_ohlcv_mocked():
     assert set(['open','high','low','close','volume','timestamp']).issubset(df.columns)
 
 
+def test_get_ohlcv_multi_mocked():
+    fake = MagicMock()
+    fake.fetch_ohlcv.return_value = [
+        [0, 1, 2, 0.5, 1.5, 100],
+        [1, 1.1, 2.1, 0.6, 1.6, 110],
+    ]
+    with patch('ccxt.binance', return_value=fake):
+        fetcher = DataFetcher()
+        data = fetcher.get_ohlcv_multi(['BTC/USDT', 'ETH/USDT'], limit=2)
+    assert set(data.keys()) == {'BTC/USDT', 'ETH/USDT'}
+    for df in data.values():
+        assert not df.empty
+
+
 def test_get_ohlcv_live():
     fetcher = DataFetcher()
     try:


### PR DESCRIPTION
## Summary
- enable DataFetcher to fetch multiple symbols
- update dashboard to display several trading pairs via tabs
- test multi-symbol fetch behaviour
- propose new multi-asset dashboard features

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603e89ca78832ba9b5220754a350c5

## Summary by Sourcery

Enable fetching and displaying multiple trading pairs concurrently in the dashboard using tabbed charts

New Features:
- Support comma-separated symbol input in the sidebar
- Add DataFetcher.get_ohlcv_multi method for multi-symbol OHLCV fetching
- Introduce tabbed charts to display each trading pair separately

Documentation:
- Document multi-asset dashboard view proposal in PROPOSALS.md

Tests:
- Add test for multi-symbol OHLCV fetch behaviour