### PR TITLE
docs: clarify monitoring modules

### DIFF
--- a/crypto-tracker-bot/server/server.js
+++ b/crypto-tracker-bot/server/server.js
@@ -1,3 +1,9 @@
+/**
+ * Express server exposing analysis and monitoring endpoints for the
+ * crypto tracker bot. It accepts uploaded chart images, proxies
+ * OpenAI requests via the apiMonitor wrapper, and streams stored
+ * price updates over WebSockets.
+ */
 const express = require('express');
 const fs = require('fs');
 const multer = require('multer');

--- a/crypto-tracker-bot/utils/apiMonitor.js
+++ b/crypto-tracker-bot/utils/apiMonitor.js
@@ -1,3 +1,11 @@
+/**
+ * Lightweight wrapper around Axios used to track request metrics.
+ *
+ * Each request updates global counters for latency and error counts
+ * and logs any calls that exceed the configured threshold. These
+ * metrics are later exposed through the `/api/health` endpoint so the
+ * dashboard can monitor the health of outbound API calls.
+ */
 const axios = require('axios');
 const logger = require('./logger');
 


### PR DESCRIPTION
## Summary
- add brief intro comment in server.js
- add header comment in apiMonitor.js

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'ccxt')*

------
https://chatgpt.com/codex/tasks/task_e_686047ed9838832b84020390586b2c30

## Summary by Sourcery

Clarify monitoring modules by adding descriptive header comments

Documentation:
- Add header comment to apiMonitor.js describing its request metrics tracking and health endpoint exposure
- Add header comment to server.js outlining its Express endpoints and functionality