### PR TITLE
Add Pushover notification support

### DIFF
--- a/crypto-tracker-bot/README.md
+++ b/crypto-tracker-bot/README.md
@@ -14,6 +14,8 @@ Set the following variables in a `.env` file inside `crypto-tracker-bot/`:
 - `TELEGRAM_BOT_TOKEN` – Telegram bot token used to send messages
 - `TELEGRAM_CHAT_ID` – Telegram chat ID where messages will be sent. Set this to the desired chat or channel ID.
 - `SLACK_WEBHOOK_URL` – Slack webhook URL for alerts
+- `PUSHOVER_TOKEN` – Pushover application token used for notifications
+- `PUSHOVER_USER_KEY` – Pushover user key to deliver messages
 - `TIINGO_API_KEY` – Tiingo API token for additional news data
 - `CRYPTO_PANICK_API_KEY` – API key for CryptoPanick news
 - `MARKETEUX_API_KEY` – Marketeux API key for curated articles
@@ -26,6 +28,13 @@ Set the following variables in a `.env` file inside `crypto-tracker-bot/`:
 - `GOOGLE_CLOUD_PROJECT_ID` – Google Cloud project ID used by Vertex AI
 - `GOOGLE_CLOUD_ACCESS_TOKEN` – Access token for the Google Cloud Vertex API
 - `PORT` – Port where the optional server listens (defaults to `3000`)
+
+### Pushover Notifications
+
+1. Create an account at [Pushover](https://pushover.net/) and create a new application.
+2. Note the application token and your user key.
+3. Add `PUSHOVER_TOKEN` and `PUSHOVER_USER_KEY` to the `.env` file.
+4. Restart the bot to enable Pushover alerts.
 
 ## Running the Bot
 

--- a/crypto-tracker-bot/__tests__/notifier.test.js
+++ b/crypto-tracker-bot/__tests__/notifier.test.js
@@ -6,12 +6,15 @@ const axios = require('axios');
 process.env.SLACK_WEBHOOK_URL = 'http://slack.test';
 process.env.DISCORD_WEBHOOK_URL = 'http://discord.test';
 process.env.TELEGRAM_BOT_TOKEN = 'token';
+process.env.PUSHOVER_TOKEN = 'apptoken';
+process.env.PUSHOVER_USER_KEY = 'userkey';
 
 // reload config-dependent modules
 delete require.cache[require.resolve('../config')];
 const { sendSlackMessage } = require('../notifier/slackNotifier');
 const { sendDiscordMessage } = require('../notifier/discordNotifier');
 const { sendTelegramMessage } = require('../notifier/telegramNotifier');
+const { sendPushoverMessage } = require('../notifier/pushoverNotifier');
 const config = require('../config');
 
 test('sendSlackMessage posts to webhook', async () => {
@@ -40,4 +43,16 @@ test('sendTelegramMessage posts to API', async () => {
   axios.post = original;
   assert.ok(calls[0].url.includes('api.telegram.org/bot' + config.telegramBotToken));
   assert.strictEqual(calls[0].payload.text, 'hello');
+});
+
+test('sendPushoverMessage posts to API', async () => {
+  const original = axios.post;
+  const calls = [];
+  axios.post = async (url, payload) => { calls.push({url, payload}); };
+  await sendPushoverMessage('push');
+  axios.post = original;
+  assert.strictEqual(calls[0].url, 'https://api.pushover.net/1/messages.json');
+  assert.strictEqual(calls[0].payload.token, config.pushoverToken);
+  assert.strictEqual(calls[0].payload.user, config.pushoverUserKey);
+  assert.strictEqual(calls[0].payload.message, 'push');
 });

--- a/crypto-tracker-bot/bot.js
+++ b/crypto-tracker-bot/bot.js
@@ -4,6 +4,7 @@ const newsTracker = require('./monitoring/newsTracker');
 const discordNotifier = require('./notifier/discordNotifier');
 const telegramNotifier = require('./notifier/telegramNotifier');
 const slackNotifier = require('./notifier/slackNotifier');
+const pushoverNotifier = require('./notifier/pushoverNotifier');
 const storage = require('./persist/storage');
 const logger = require('./utils/logger');
 const sentimentAnalysis = require('./technicalIndicators/sentimentAnalysis');
@@ -42,6 +43,7 @@ async function checkPrices() {
         await discordNotifier.sendDiscordMessage(message);
         await telegramNotifier.sendTelegramMessage(message);
         await slackNotifier.sendSlackMessage(message);
+        await pushoverNotifier.sendPushoverMessage(message);
         logger.info(`Notification sent for ${symbol}`);
 
         const sentimentResult = await sentimentAnalysis.analyzeData({ symbol, currentPrice, changePercent, changeDollar });
@@ -59,6 +61,7 @@ async function checkPrices() {
           await discordNotifier.sendDiscordMessage(trendMsg);
           await telegramNotifier.sendTelegramMessage(trendMsg);
           await slackNotifier.sendSlackMessage(trendMsg);
+          await pushoverNotifier.sendPushoverMessage(trendMsg);
         }
       }
       previousPrices[symbol] = currentPrice;

--- a/crypto-tracker-bot/config.js
+++ b/crypto-tracker-bot/config.js
@@ -20,6 +20,8 @@ const {
   STORAGE_INTERVAL,
   GOOGLE_CLOUD_PROJECT_ID,
   GOOGLE_CLOUD_ACCESS_TOKEN,
+  PUSHOVER_TOKEN,
+  PUSHOVER_USER_KEY,
 } = process.env;
 
 module.exports = {
@@ -43,4 +45,6 @@ module.exports = {
   storageInterval: parseInt(STORAGE_INTERVAL) || 300000,
   googleCloudProjectId: GOOGLE_CLOUD_PROJECT_ID,
   googleCloudAccessToken: GOOGLE_CLOUD_ACCESS_TOKEN,
+  pushoverToken: PUSHOVER_TOKEN,
+  pushoverUserKey: PUSHOVER_USER_KEY,
 };

--- a/crypto-tracker-bot/notifier/pushoverNotifier.js
+++ b/crypto-tracker-bot/notifier/pushoverNotifier.js
@@ -1,0 +1,26 @@
+const axios = require('axios');
+const { pushoverToken, pushoverUserKey } = require('../config');
+const logger = require('../utils/logger');
+
+/**
+ * Send a notification via the Pushover service.
+ *
+ * @param {string} message - The message to send.
+ */
+async function sendPushoverMessage(message) {
+  if (!pushoverToken || !pushoverUserKey) {
+    logger.error('Pushover token or user key not configured');
+    return;
+  }
+  try {
+    await axios.post('https://api.pushover.net/1/messages.json', {
+      token: pushoverToken,
+      user: pushoverUserKey,
+      message,
+    });
+  } catch (error) {
+    logger.error('Pushover notification error:', error);
+  }
+}
+
+module.exports = { sendPushoverMessage };


### PR DESCRIPTION
## Summary
- support sending alerts through Pushover
- call the new notifier from `bot.js`
- document env vars and setup steps in README
- cover the notifier with automated tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686047f0874c832bb542e97661c72e3f

## Summary by Sourcery

Add support for sending alerts via Pushover by introducing a dedicated notifier, integrating it into the bot’s notification flow, and covering it with configuration, documentation, and tests.

New Features:
- Add pushoverNotifier module to send messages through the Pushover API
- Integrate Pushover notifications into the bot’s alert and trend workflows

Enhancements:
- Load PUSHOVER_TOKEN and PUSHOVER_USER_KEY from environment in configuration

Documentation:
- Document Pushover setup steps and required environment variables in README

Tests:
- Add automated tests for sendPushoverMessage to verify API requests