### PR TITLE
Add ML strategy explorer page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 - `npm run server` – launch the optional analysis server
 - `auto_install_and_run.sh` – install Node modules and run both the bot and server
 - `streamlit run trading_bot/app.py` – start the trading dashboard
-- `streamlit run trading_bot/strategy_explorer.py` – explore ML models on historical data
+- `streamlit run trading_bot/strategy_explorer.py` – explore ML models and view cross-validated performance
 
 ## Running
 
@@ -42,12 +42,13 @@ pip install -r requirements.txt
   ```bash
   streamlit run trading_bot/app.py
   ```
-- **Run the strategy explorer:**
+ - **Run the strategy explorer:**
   ```bash
   streamlit run trading_bot/strategy_explorer.py
   ```
-  This page supports hyperparameter tuning, feature-importance charts,
-  and persists evaluation results for later review.
+  This page supports hyperparameter tuning, cross‑validated accuracy,
+  feature-importance charts, and persists evaluation results for later
+  review.
 
 - **Quick start both bot and server:**
   ```bash

--- a/trading_bot/strategy_explorer.py
+++ b/trading_bot/strategy_explorer.py
@@ -1,101 +1,100 @@
-import streamlit as st
+"""Streamlit page for exploring machine-learning strategies.
+
+Users can select a model (logistic regression or random forest),
+optionally perform hyperparameter tuning, and view cross‑validated
+accuracy on historical OHLCV data. Results are persisted for
+later review.
+"""
+
+from __future__ import annotations
+
 import pandas as pd
-from sklearn.linear_model import LogisticRegression
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.model_selection import cross_val_score, TimeSeriesSplit, GridSearchCV
-from sklearn.preprocessing import StandardScaler
-from sklearn.pipeline import Pipeline
 import plotly.express as px
-
-from data_fetcher import DataFetcher
-from indicator_calculator import add_indicators
-from results_db import save_evaluation, load_evaluations
-from sklearn.model_selection import cross_val_score, TimeSeriesSplit
-from sklearn.preprocessing import StandardScaler
+import streamlit as st
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import GridSearchCV, TimeSeriesSplit, cross_val_score
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
 from data_fetcher import DataFetcher
 from indicator_calculator import add_indicators
+from results_db import load_evaluations, save_evaluation
 
 st.set_page_config(page_title="Strategy Explorer")
 
-st.title("ML Strategy Explorer")
-
-symbol = st.sidebar.text_input("Trading Pair", value="BTC/USDT")
-timeframe = st.sidebar.text_input("Timeframe", value="1h")
-model_name = st.sidebar.selectbox(
-    "Model", ["Logistic Regression", "Random Forest"]
-)
-splits = st.sidebar.slider(
-    "Cross-Validation Splits", min_value=2, max_value=10, value=5
-)
-perform_tuning = st.sidebar.checkbox("Hyperparameter Tuning")
-
 
 @st.cache_data(ttl=3600)
-def load_data(sym: str, tf: str) -> pd.DataFrame:
+def load_data(symbol: str, timeframe: str) -> pd.DataFrame:
+    """Fetch and cache market data with indicators."""
+
     fetcher = DataFetcher()
-    df = fetcher.get_ohlcv(symbol=sym, timeframe=tf, limit=1000)
+    df = fetcher.get_ohlcv(symbol=symbol, timeframe=timeframe, limit=1000)
     df = add_indicators(df)
     df.dropna(inplace=True)
     return df
 
-df = load_data(symbol, timeframe)
-X = df[["rsi", "ema", "adx"]]
-y = (df["close"].shift(-1) > df["close"]).astype(int)
-X = X[:-1]
-y = y[:-1]
 
-if model_name == "Logistic Regression":
-    base_model = Pipeline([
-        ("scaler", StandardScaler()),
-        ("clf", LogisticRegression(max_iter=200)),
-    ])
-    param_grid = {"clf__C": [0.01, 0.1, 1.0, 10.0]}
-else:
-    base_model = RandomForestClassifier(n_estimators=100, random_state=42)
-    param_grid = {"n_estimators": [100, 200], "max_depth": [None, 5, 10]}
+# Sidebar controls
+st.title("ML Strategy Explorer")
+symbol = st.sidebar.text_input("Trading Pair", value="BTC/USDT")
+timeframe = st.sidebar.text_input("Timeframe", value="1h")
+model_name = st.sidebar.selectbox("Model", ["Logistic Regression", "Random Forest"])
+splits = st.sidebar.slider("Cross-Validation Splits", min_value=2, max_value=10, value=5)
+perform_tuning = st.sidebar.checkbox("Hyperparameter Tuning")
+
+# Load data and prepare features/labels
+history = load_data(symbol, timeframe)
+X = history[["rsi", "ema", "adx"]]
+y = (history["close"].shift(-1) > history["close"]).astype(int)
+X, y = X[:-1], y[:-1]
+
+# Model definitions and parameter grids
+model_defs: dict[str, Pipeline | RandomForestClassifier] = {
+    "Logistic Regression": Pipeline(
+        [
+            ("scaler", StandardScaler()),
+            ("clf", LogisticRegression(max_iter=200)),
+        ]
+    ),
+    "Random Forest": RandomForestClassifier(n_estimators=100, random_state=42),
+}
+param_grids = {
+    "Logistic Regression": {"clf__C": [0.01, 0.1, 1.0, 10.0]},
+    "Random Forest": {"n_estimators": [100, 200], "max_depth": [None, 5, 10]},
+}
 
 cv = TimeSeriesSplit(n_splits=splits)
 
 if perform_tuning:
-    search = GridSearchCV(base_model, param_grid, cv=cv, scoring="accuracy")
+    search = GridSearchCV(model_defs[model_name], param_grids[model_name], cv=cv, scoring="accuracy")
     search.fit(X, y)
     model = search.best_estimator_
     params = search.best_params_
 else:
-    model = base_model
+    model = model_defs[model_name]
     params = {}
 
 scores = cross_val_score(model, X, y, cv=cv, scoring="accuracy")
 model.fit(X, y)
 
+# Compute feature importance
 if model_name == "Logistic Regression":
     coef = model.named_steps["clf"].coef_[0]
     importance = dict(zip(["rsi", "ema", "adx"], coef))
 else:
     importance = dict(zip(["rsi", "ema", "adx"], model.feature_importances_))
 
+# Persist evaluation
 save_evaluation(symbol, timeframe, model_name, params, scores, importance)
-    model = Pipeline([
-        ("scaler", StandardScaler()),
-        ("clf", LogisticRegression(max_iter=200)),
-    ])
-else:
-    model = RandomForestClassifier(n_estimators=100, random_state=42)
 
-cv = TimeSeriesSplit(n_splits=splits)
-scores = cross_val_score(model, X, y, cv=cv, scoring="accuracy")
-
+# Display results
 st.write(f"Mean accuracy: {scores.mean():.3f} ± {scores.std():.3f}")
-
 st.line_chart(pd.Series(scores, name="Accuracy"))
-
 fig = px.bar(x=list(importance.keys()), y=list(importance.values()), labels={"x": "Feature", "y": "Importance"}, title="Feature Importance")
 st.plotly_chart(fig, use_container_width=True)
 
 st.subheader("Saved Evaluations")
-history = pd.DataFrame(load_evaluations())
-if not history.empty:
-    st.dataframe(history)
-
+history_df = pd.DataFrame(load_evaluations())
+if not history_df.empty:
+    st.dataframe(history_df)

--- a/trading_bot/tests/test_backtester.py
+++ b/trading_bot/tests/test_backtester.py
@@ -1,45 +1,43 @@
-import sys
 import os
+import sys
 
-import sys, os
+# Ensure the package can be imported when tests run from repo root
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 import pandas as pd
+from trading_bot.backtester import backtest, BacktestReport
 
-# Ensure imports work when running tests from the repository root
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-from trading_bot.backtester import backtest
 
 def test_backtest_returns_report():
     df = pd.DataFrame({
-        'vwap': [0.9, 0.95, 1.0],
-        'rsi': [20, 40, 20],
-        'close': [1.0, 1.1, 1.2]
+        "vwap": [0.9, 0.95, 1.0],
+        "rsi": [20, 40, 20],
+        "close": [1.0, 1.1, 1.2],
     })
-    result = backtest(df)
-    assert result > 1.0
+    report = backtest(df)
+    assert isinstance(report, BacktestReport)
+    assert report.final_balance > 1.0
 
 
 def test_stop_loss_triggered():
     df = pd.DataFrame({
-        'vwap': [0.9, 0.9, 0.9],
-        'rsi': [20, 40, 40],
-        'close': [1.0, 1.05, 0.8],
-        'high': [1.1, 1.1, 1.05],
-        'low': [0.9, 1.0, 0.75]
+        "vwap": [0.9, 0.9, 0.9],
+        "rsi": [20, 40, 40],
+        "close": [1.0, 1.05, 0.8],
+        "high": [1.1, 1.1, 1.05],
+        "low": [0.9, 1.0, 0.75],
     })
-    result = backtest(df)
-    assert result < 1.0
     report = backtest(df)
-    assert report.final_balance > 1.0
+    assert report.final_balance < 1.0
 
 
 def test_backtest_creates_report_files(tmp_path):
     df = pd.DataFrame({
-        'vwap': [0.9, 0.95, 1.0],
-        'rsi': [20, 40, 20],
-        'close': [1.0, 1.1, 1.2]
+        "vwap": [0.9, 0.95, 1.0],
+        "rsi": [20, 40, 20],
+        "close": [1.0, 1.1, 1.2],
     })
     report = backtest(df, report_dir=tmp_path)
-    assert (tmp_path / 'stats.json').exists()
-    assert (tmp_path / 'equity_curve.png').exists()
+    assert isinstance(report, BacktestReport)
+    assert (tmp_path / "stats.json").exists()
+    assert (tmp_path / "equity_curve.png").exists()


### PR DESCRIPTION
## Summary
- add a Streamlit page for exploring ML models with cross-validation
- refine tests for the backtester
- document launching the strategy explorer in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q trading_bot/tests`

------
https://chatgpt.com/codex/tasks/task_e_686047f0dd48832b8f17752672ede82b

## Summary by Sourcery

Add a new Streamlit-based ML Strategy Explorer page to select and tune models, display cross-validated accuracy and feature importance, and persist evaluation results.

New Features:
- Introduce strategy_explorer.py Streamlit app for ML model selection, hyperparameter tuning, cross-validated performance display, and result persistence.

Enhancements:
- Refactor strategy_explorer code with consolidated model definitions, streamlined data loading, renamed variables, and added module-level docstring.

Documentation:
- Update README with instructions for launching the strategy explorer and details on cross-validated performance display.

Tests:
- Refine backtester tests to assert BacktestReport instances, validate final_balance thresholds, and ensure report files are generated.