### PR TITLE
Refactor backtester to use strategy interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,16 +129,17 @@ requirements.txt      # Python dependencies
 ## Custom Strategies
 
 The backtester accepts any strategy class located in `trading_bot/strategies/`.
-Create a module in that folder and subclass `Strategy`:
+Create a module in that folder and subclass :class:`Strategy`:
 
 ```python
 from trading_bot.strategies.base import Strategy
 import pandas as pd
 
 class MyStrategy(Strategy):
-    def generate_signals(self, df: pd.DataFrame) -> float:
-        # Implement trading logic and return a final balance
-        return 1.0
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        """Generate an equity curve from ``df``."""
+
+        return pd.Series([1.0] * len(df), index=df.index)
 
 ```
 

--- a/trading_bot/backtester.py
+++ b/trading_bot/backtester.py
@@ -1,10 +1,12 @@
+"""Simple backtesting framework for evaluating trading strategies."""
+
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 import json
-import matplotlib.pyplot as plt
 
+import matplotlib.pyplot as plt
 import pandas as pd
 
 from trading_bot.strategies.base import Strategy
@@ -12,48 +14,45 @@ from trading_bot.risk import add_stop_levels
 
 
 class SimpleStrategy(Strategy):
-    """Reimplements the original hard-coded logic as a strategy class."""
+    """Baseline strategy using VWAP and RSI crosses with dynamic stops."""
 
-    def generate_signals(self, df: pd.DataFrame) -> float:
-        df = add_stop_levels(df)
-        position = 0
-        balance = 1.0
-        stop_loss = None
-        take_profit = None
-        for _, row in df.iterrows():
-            if position == 0:
-                if row['close'] > row['vwap'] and row['rsi'] < 30:
-                    position = balance / row['close']
-                    balance = 0
-                    stop_loss = row['stop_loss']
-                    take_profit = row['take_profit']
-            else:
-                if row['close'] <= stop_loss or row['close'] >= take_profit:
-                    balance = position * row['close']
-                    position = 0
-                elif row['close'] < row['vwap'] or row['rsi'] > 70:
-                    balance = position * row['close']
-                    position = 0
     def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        """Return an equity curve for ``df`` using a basic trading logic."""
+
+        df = add_stop_levels(df)
         position = 0.0
         balance = 1.0
         equity = []
+        stop_loss = take_profit = None
+
         for _, row in df.iterrows():
-            if row["close"] > row["vwap"] and row["rsi"] < 30 and position == 0:
-                position = balance / row["close"]
-                balance = 0.0
-            elif position and (row["close"] < row["vwap"] or row["rsi"] > 70):
-                balance = position * row["close"]
-                position = 0.0
+            if not position:
+                if row["close"] > row["vwap"] and row["rsi"] < 30:
+                    position = balance / row["close"]
+                    balance = 0.0
+                    stop_loss = row["stop_loss"]
+                    take_profit = row["take_profit"]
+            else:
+                if row["close"] <= stop_loss or row["close"] >= take_profit:
+                    balance = position * row["close"]
+                    position = 0.0
+                elif row["close"] < row["vwap"] or row["rsi"] > 70:
+                    balance = position * row["close"]
+                    position = 0.0
+
             equity.append(balance + position * row["close"])
+
         if position:
             balance = position * df.iloc[-1]["close"]
             equity[-1] = balance
+
         return pd.Series(equity, index=df.index[: len(equity)])
 
 
 @dataclass
 class BacktestReport:
+    """Results produced by :func:`backtest`."""
+
     final_balance: float
     profit: float
     max_drawdown: float

--- a/trading_bot/strategies/base.py
+++ b/trading_bot/strategies/base.py
@@ -1,11 +1,29 @@
+"""Common interface for trading strategies used by the backtester."""
+
 from abc import ABC, abstractmethod
+from typing import Any
+
 import pandas as pd
 
 
 class Strategy(ABC):
-    """Abstract trading strategy."""
+    """Abstract base class for all trading strategies."""
 
     @abstractmethod
-    def generate_signals(self, df: pd.DataFrame):
-        """Return trading signals or backtest results for the given data."""
-        pass
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        """Return an equity curve or trading signals for ``df``.
+
+        Parameters
+        ----------
+        df:
+            Price history with required indicator columns.
+
+        Returns
+        -------
+        pd.Series
+            Series representing the strategy equity over time or the signals
+            used by :func:`trading_bot.backtester.backtest`.
+        """
+
+        raise NotImplementedError
+

--- a/trading_bot/tests/test_backtester.py
+++ b/trading_bot/tests/test_backtester.py
@@ -1,13 +1,10 @@
-import sys
 import os
+import sys
 
-import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 import pandas as pd
 
-# Ensure imports work when running tests from the repository root
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 from trading_bot.backtester import backtest
 
 def test_backtest_returns_report():
@@ -16,8 +13,8 @@ def test_backtest_returns_report():
         'rsi': [20, 40, 20],
         'close': [1.0, 1.1, 1.2]
     })
-    result = backtest(df)
-    assert result > 1.0
+    report = backtest(df)
+    assert report.final_balance > 1.0
 
 
 def test_stop_loss_triggered():
@@ -28,10 +25,10 @@ def test_stop_loss_triggered():
         'high': [1.1, 1.1, 1.05],
         'low': [0.9, 1.0, 0.75]
     })
-    result = backtest(df)
-    assert result < 1.0
     report = backtest(df)
-    assert report.final_balance > 1.0
+    assert report.final_balance < 1.0
+    report2 = backtest(df)
+    assert isinstance(report2.final_balance, float)
 
 
 def test_backtest_creates_report_files(tmp_path):


### PR DESCRIPTION
## Summary
- define abstract `Strategy` class in `strategies/base.py`
- clean up `backtester` and implement pluggable strategy pattern
- update tests for new `BacktestReport` return type
- document how to create custom strategies

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686047f91138832bafc34202e5f412b2

## Summary by Sourcery

Refactor the backtester to use a pluggable Strategy interface and return a structured BacktestReport, update SimpleStrategy, adjust tests, and refresh documentation.

New Features:
- Introduce Strategy abstract base class in trading_bot/strategies/base.py for pluggable strategy support.

Enhancements:
- Refactor backtest function to return a BacktestReport dataclass with final_balance, profit, and max_drawdown fields.
- Update SimpleStrategy to implement the Strategy interface and produce an equity curve as a pandas Series with dynamic stop-loss and take-profit logic.

Documentation:
- Update README custom strategies section to demonstrate subclassing Strategy and returning a pandas Series equity curve.

Tests:
- Revise tests to expect a BacktestReport return value and assert on the final_balance property, including type validation.