### PR TITLE
Add backtest report generation with stats and tests

### DIFF
--- a/trading_bot/app.py
+++ b/trading_bot/app.py
@@ -7,6 +7,8 @@ from sentiment import analyze_sentiment
 from ml_model import PriceDirectionModel
 from backtester import backtest
 
+REPORT_DIR = "trading_bot/reports"
+
 st.set_page_config(page_title="Crypto Dashboard", layout="wide")
 
 fetcher = DataFetcher()
@@ -39,8 +41,13 @@ for sym, tab in zip(symbols, tabs):
         current_price = fetcher.get_current_price(sym)
 
         if run_backtest:
-            result = backtest(data)
-            st.write(f"Backtest balance: {result:.2f}")
+            report = backtest(data, report_dir=REPORT_DIR)
+            st.write(f"Balance: {report.final_balance:.2f}")
+            st.write(f"Profit: {report.profit:.2f}")
+            st.write(f"Max DD: {report.max_drawdown:.2%}")
+            st.write(f"Trades: {report.num_trades}")
+            if report.figure_path:
+                st.image(report.figure_path)
 
         sentiment_score = analyze_sentiment([])
         model_prob = model.predict(data)
@@ -94,41 +101,6 @@ for sym, tab in zip(symbols, tabs):
         col1, col2 = st.columns(2)
         col1.write(f"Sentiment score: {sentiment_score}")
         col2.write(f"Model long probability: {model_prob}")
-
-data = load_data()
-current_price = fetcher.get_current_price(symbol)
-
-if run_backtest:
-    report = backtest(data, report_dir="trading_bot/reports")
-    st.sidebar.write(f"Backtest balance: {report.final_balance:.2f}")
-    st.sidebar.write(f"Profit: {report.profit:.2f}")
-    st.sidebar.write(f"Max DD: {report.max_drawdown:.2%}")
-    st.sidebar.write(f"Trades: {report.num_trades}")
-    if report.figure_path:
-        st.image(report.figure_path)
-
-sentiment_score = analyze_sentiment([])
-model_prob = model.predict(data)
-
-st.metric("Current Price", current_price)
-fig = go.Figure(data=[go.Candlestick(x=data['timestamp'],
-                open=data['open'], high=data['high'],
-                low=data['low'], close=data['close'])])
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['vwap'], name='VWAP'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['ema'], name='EMA'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['sma'], name='SMA'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['support'], name='Support', line=dict(dash='dot')))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['resistance'], name='Resistance', line=dict(dash='dot')))
-fractals_up = data[data['fractal_up']]
-fractals_down = data[data['fractal_down']]
-fig.add_trace(go.Scatter(x=fractals_up['timestamp'], y=fractals_up['high'], mode='markers', marker_symbol='triangle-up', marker_color='green', name='Fractal Up'))
-fig.add_trace(go.Scatter(x=fractals_down['timestamp'], y=fractals_down['low'], mode='markers', marker_symbol='triangle-down', marker_color='red', name='Fractal Down'))
-
-st.plotly_chart(fig, use_container_width=True)
-
-col1, col2 = st.columns(2)
-col1.write(f"Sentiment score: {sentiment_score}")
-col2.write(f"Model long probability: {model_prob}")
 
 if refresh_btn:
     st.experimental_rerun()

--- a/trading_bot/backtester.py
+++ b/trading_bot/backtester.py
@@ -1,10 +1,16 @@
+"""Simple backtesting utilities.
+
+This module provides a basic backtester capable of evaluating a trading
+:class:`Strategy` on a pandas ``DataFrame``. It outputs key performance
+statistics and optionally saves a JSON report and an equity curve plot.
+"""
+
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 import json
 import matplotlib.pyplot as plt
-
 import pandas as pd
 
 from trading_bot.strategies.base import Strategy
@@ -12,48 +18,55 @@ from trading_bot.risk import add_stop_levels
 
 
 class SimpleStrategy(Strategy):
-    """Reimplements the original hard-coded logic as a strategy class."""
+    """Minimal example strategy used by the backtester."""
 
-    def generate_signals(self, df: pd.DataFrame) -> float:
+    def generate_signals(self, df: pd.DataFrame) -> tuple[pd.Series, int]:
+        """Return the equity curve and trade count for ``df``.
+
+        The strategy buys when price closes above VWAP with oversold RSI and
+        exits on the opposite conditions or when dynamic stop levels are hit.
+        """
+
         df = add_stop_levels(df)
-        position = 0
-        balance = 1.0
-        stop_loss = None
-        take_profit = None
-        for _, row in df.iterrows():
-            if position == 0:
-                if row['close'] > row['vwap'] and row['rsi'] < 30:
-                    position = balance / row['close']
-                    balance = 0
-                    stop_loss = row['stop_loss']
-                    take_profit = row['take_profit']
-            else:
-                if row['close'] <= stop_loss or row['close'] >= take_profit:
-                    balance = position * row['close']
-                    position = 0
-                elif row['close'] < row['vwap'] or row['rsi'] > 70:
-                    balance = position * row['close']
-                    position = 0
-    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
         position = 0.0
         balance = 1.0
-        equity = []
+        stop_loss = take_profit = None
+        trades = 0
+        equity: list[float] = []
+
         for _, row in df.iterrows():
-            if row["close"] > row["vwap"] and row["rsi"] < 30 and position == 0:
-                position = balance / row["close"]
-                balance = 0.0
-            elif position and (row["close"] < row["vwap"] or row["rsi"] > 70):
-                balance = position * row["close"]
-                position = 0.0
+            if not position:
+                if row["close"] > row["vwap"] and row["rsi"] < 30:
+                    position = balance / row["close"]
+                    balance = 0.0
+                    stop_loss = row["stop_loss"]
+                    take_profit = row["take_profit"]
+                    trades += 1
+            else:
+                if row["close"] >= take_profit or row["close"] <= stop_loss:
+                    balance = position * row["close"]
+                    position = 0.0
+                    trades += 1
+                elif row["close"] < row["vwap"] or row["rsi"] > 70:
+                    balance = position * row["close"]
+                    position = 0.0
+                    trades += 1
+                else:
+                    stop_loss = row["stop_loss"]
+                    take_profit = row["take_profit"]
             equity.append(balance + position * row["close"])
+
         if position:
             balance = position * df.iloc[-1]["close"]
             equity[-1] = balance
-        return pd.Series(equity, index=df.index[: len(equity)])
+
+        return pd.Series(equity, index=df.index[: len(equity)]), trades
 
 
 @dataclass
 class BacktestReport:
+    """Container for backtest results."""
+
     final_balance: float
     profit: float
     max_drawdown: float
@@ -64,27 +77,26 @@ class BacktestReport:
 
 
 def backtest(
-    df: pd.DataFrame, strategy: Optional[Strategy] = None, report_dir: Optional[str] = None
+    df: pd.DataFrame,
+    strategy: Optional[Strategy] = None,
+    report_dir: Optional[str] = None,
 ) -> BacktestReport:
-    """Run ``df`` through the provided strategy and optionally save a report."""
+    """Run ``df`` through ``strategy`` and return performance metrics."""
 
     strategy = strategy or SimpleStrategy()
-    equity_curve = strategy.generate_signals(df)
+    equity_curve, trades = strategy.generate_signals(df)
 
-    final_balance = float(equity_curve.iloc[-1])
+    final_balance = float(equity_curve.iloc[-1]) if not equity_curve.empty else 1.0
     profit = final_balance - 1.0
     running_max = equity_curve.cummax()
     drawdowns = (equity_curve - running_max) / running_max
     max_drawdown = float(drawdowns.min()) if not drawdowns.empty else 0.0
 
-    # Count trades as number of changes in position
-    num_trades = int((equity_curve.diff() != 0).sum())
-
-    stats_path = None
-    figure_path = None
+    stats_path = figure_path = None
     if report_dir:
         report_dir_path = Path(report_dir)
         report_dir_path.mkdir(parents=True, exist_ok=True)
+
         stats_path = str(report_dir_path / "stats.json")
         with open(stats_path, "w") as f:
             json.dump(
@@ -92,7 +104,7 @@ def backtest(
                     "final_balance": final_balance,
                     "profit": profit,
                     "max_drawdown": max_drawdown,
-                    "num_trades": num_trades,
+                    "num_trades": trades,
                 },
                 f,
             )
@@ -111,7 +123,7 @@ def backtest(
         final_balance=final_balance,
         profit=profit,
         max_drawdown=max_drawdown,
-        num_trades=num_trades,
+        num_trades=trades,
         equity_curve=equity_curve,
         stats_path=stats_path,
         figure_path=figure_path,

--- a/trading_bot/tests/test_backtester.py
+++ b/trading_bot/tests/test_backtester.py
@@ -1,45 +1,49 @@
-import sys
 import os
-
-import sys, os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-
+import sys
 import pandas as pd
 
-# Ensure imports work when running tests from the repository root
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-from trading_bot.backtester import backtest
+
+from trading_bot.backtester import backtest, BacktestReport
+
+
+def sample_df() -> pd.DataFrame:
+    """Return a small DataFrame for testing."""
+    return pd.DataFrame(
+        {
+            "vwap": [0.9, 0.95, 1.0],
+            "rsi": [20, 40, 20],
+            "close": [1.0, 1.1, 1.2],
+        }
+    )
+
 
 def test_backtest_returns_report():
-    df = pd.DataFrame({
-        'vwap': [0.9, 0.95, 1.0],
-        'rsi': [20, 40, 20],
-        'close': [1.0, 1.1, 1.2]
-    })
-    result = backtest(df)
-    assert result > 1.0
+    report = backtest(sample_df())
+    assert isinstance(report, BacktestReport)
+    assert report.final_balance > 1.0
+    assert report.num_trades >= 0
 
 
 def test_stop_loss_triggered():
-    df = pd.DataFrame({
-        'vwap': [0.9, 0.9, 0.9],
-        'rsi': [20, 40, 40],
-        'close': [1.0, 1.05, 0.8],
-        'high': [1.1, 1.1, 1.05],
-        'low': [0.9, 1.0, 0.75]
-    })
-    result = backtest(df)
-    assert result < 1.0
+    df = pd.DataFrame(
+        {
+            "vwap": [0.9, 0.9, 0.9],
+            "rsi": [20, 40, 40],
+            "close": [1.0, 1.05, 0.8],
+            "high": [1.1, 1.1, 1.05],
+            "low": [0.9, 1.0, 0.75],
+        }
+    )
     report = backtest(df)
-    assert report.final_balance > 1.0
+    assert isinstance(report, BacktestReport)
+    assert report.final_balance < 1.0
 
 
 def test_backtest_creates_report_files(tmp_path):
-    df = pd.DataFrame({
-        'vwap': [0.9, 0.95, 1.0],
-        'rsi': [20, 40, 20],
-        'close': [1.0, 1.1, 1.2]
-    })
-    report = backtest(df, report_dir=tmp_path)
-    assert (tmp_path / 'stats.json').exists()
-    assert (tmp_path / 'equity_curve.png').exists()
+    report = backtest(sample_df(), report_dir=tmp_path)
+    assert (tmp_path / "stats.json").is_file()
+    assert (tmp_path / "equity_curve.png").is_file()
+    # paths should be recorded in the report
+    assert os.path.samefile(report.stats_path, tmp_path / "stats.json")
+    assert os.path.samefile(report.figure_path, tmp_path / "equity_curve.png")


### PR DESCRIPTION
## Summary
- extend backtester to compute profit, max drawdown and number of trades
- write report files (stats JSON & equity curve plot)
- show backtest results in Streamlit dashboard
- add unit tests checking report files

## Testing
- `pytest trading_bot/tests/test_backtester.py -q`
- `pytest -q trading_bot/tests`

------
https://chatgpt.com/codex/tasks/task_e_686047f68390832b82d52cfc728ecb8d

## Summary by Sourcery

Extend the backtesting module to produce detailed performance metrics and reports (stats JSON and plot), integrate those results into the Streamlit UI, and add unit tests to validate report generation and strategy behavior.

New Features:
- Compute profit, max drawdown, and trade count in the backtester and return them in a BacktestReport
- Save backtest statistics as JSON and generate an equity‐curve plot when a report directory is provided
- Expose backtest metrics and equity‐curve image within the Streamlit dashboard

Enhancements:
- Refactor generate_signals to return both the equity curve and trade count
- Introduce BacktestReport dataclass to encapsulate backtest results

Tests:
- Add unit tests for backtesting behavior, stop‐loss triggering, and report file creation