### PR TITLE
Add multi-symbol dashboard support

### DIFF
--- a/trading_bot/app.py
+++ b/trading_bot/app.py
@@ -1,8 +1,9 @@
+"""Streamlit dashboard for visualising multiple crypto pairs simultaneously."""
+
 import streamlit as st
-import pandas as pd
 import plotly.graph_objects as go
 from data_fetcher import DataFetcher
-from indicator_calculator import add_indicators, find_fractals, support_resistance
+from indicator_calculator import compute_indicators_batch
 from sentiment import analyze_sentiment
 from ml_model import PriceDirectionModel
 from backtester import backtest
@@ -16,31 +17,28 @@ symbols_input = st.sidebar.text_input(
     "Trading Pairs (comma separated)", value="BTC/USDT"
 )
 symbols = [s.strip().upper() for s in symbols_input.split(",") if s.strip()]
-refresh = st.sidebar.number_input("Refresh (s)", min_value=5, value=30)
 run_backtest = st.sidebar.button("Run Backtest")
 refresh_btn = st.sidebar.button("Refresh Now")
 
-@st.cache_data(ttl=60)
-def load_data(sym: str):
-    df = fetcher.get_ohlcv(sym, timeframe="1m", limit=500)
-    df = add_indicators(df)
-    df = find_fractals(df)
-    lows, highs = support_resistance(df)
-    df["support"] = lows
-    df["resistance"] = highs
-    model.train(df)
-    return df
 
+@st.cache_data(ttl=60)
+def load_all(symbols: list[str]):
+    data = fetcher.get_ohlcv_multi(symbols, timeframe="1m", limit=500)
+    data = compute_indicators_batch(data)
+    return data
+
+data_dict = load_all(symbols)
 tabs = st.tabs(symbols)
 
 for sym, tab in zip(symbols, tabs):
     with tab:
-        data = load_data(sym)
+        data = data_dict[sym]
+        model.train(data)
         current_price = fetcher.get_current_price(sym)
 
         if run_backtest:
             result = backtest(data)
-            st.write(f"Backtest balance: {result:.2f}")
+            st.write(f"Backtest balance: {result.final_balance:.2f}")
 
         sentiment_score = analyze_sentiment([])
         model_prob = model.predict(data)
@@ -94,41 +92,6 @@ for sym, tab in zip(symbols, tabs):
         col1, col2 = st.columns(2)
         col1.write(f"Sentiment score: {sentiment_score}")
         col2.write(f"Model long probability: {model_prob}")
-
-data = load_data()
-current_price = fetcher.get_current_price(symbol)
-
-if run_backtest:
-    report = backtest(data, report_dir="trading_bot/reports")
-    st.sidebar.write(f"Backtest balance: {report.final_balance:.2f}")
-    st.sidebar.write(f"Profit: {report.profit:.2f}")
-    st.sidebar.write(f"Max DD: {report.max_drawdown:.2%}")
-    st.sidebar.write(f"Trades: {report.num_trades}")
-    if report.figure_path:
-        st.image(report.figure_path)
-
-sentiment_score = analyze_sentiment([])
-model_prob = model.predict(data)
-
-st.metric("Current Price", current_price)
-fig = go.Figure(data=[go.Candlestick(x=data['timestamp'],
-                open=data['open'], high=data['high'],
-                low=data['low'], close=data['close'])])
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['vwap'], name='VWAP'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['ema'], name='EMA'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['sma'], name='SMA'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['support'], name='Support', line=dict(dash='dot')))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['resistance'], name='Resistance', line=dict(dash='dot')))
-fractals_up = data[data['fractal_up']]
-fractals_down = data[data['fractal_down']]
-fig.add_trace(go.Scatter(x=fractals_up['timestamp'], y=fractals_up['high'], mode='markers', marker_symbol='triangle-up', marker_color='green', name='Fractal Up'))
-fig.add_trace(go.Scatter(x=fractals_down['timestamp'], y=fractals_down['low'], mode='markers', marker_symbol='triangle-down', marker_color='red', name='Fractal Down'))
-
-st.plotly_chart(fig, use_container_width=True)
-
-col1, col2 = st.columns(2)
-col1.write(f"Sentiment score: {sentiment_score}")
-col2.write(f"Model long probability: {model_prob}")
 
 if refresh_btn:
     st.experimental_rerun()

--- a/trading_bot/backtester.py
+++ b/trading_bot/backtester.py
@@ -1,3 +1,5 @@
+"""Simple backtester used for evaluating strategies."""
+
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -12,43 +14,36 @@ from trading_bot.risk import add_stop_levels
 
 
 class SimpleStrategy(Strategy):
-    """Reimplements the original hard-coded logic as a strategy class."""
+    """Reimplements the original trading logic and returns an equity curve."""
 
-    def generate_signals(self, df: pd.DataFrame) -> float:
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
         df = add_stop_levels(df)
-        position = 0
+        position = 0.0
         balance = 1.0
         stop_loss = None
         take_profit = None
-        for _, row in df.iterrows():
-            if position == 0:
-                if row['close'] > row['vwap'] and row['rsi'] < 30:
-                    position = balance / row['close']
-                    balance = 0
-                    stop_loss = row['stop_loss']
-                    take_profit = row['take_profit']
-            else:
-                if row['close'] <= stop_loss or row['close'] >= take_profit:
-                    balance = position * row['close']
-                    position = 0
-                elif row['close'] < row['vwap'] or row['rsi'] > 70:
-                    balance = position * row['close']
-                    position = 0
-    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
-        position = 0.0
-        balance = 1.0
         equity = []
+
         for _, row in df.iterrows():
-            if row["close"] > row["vwap"] and row["rsi"] < 30 and position == 0:
-                position = balance / row["close"]
-                balance = 0.0
-            elif position and (row["close"] < row["vwap"] or row["rsi"] > 70):
-                balance = position * row["close"]
-                position = 0.0
+            if position == 0.0:
+                if row["close"] > row["vwap"] and row["rsi"] < 30:
+                    position = balance / row["close"]
+                    balance = 0.0
+                    stop_loss = row["stop_loss"]
+                    take_profit = row["take_profit"]
+            else:
+                if row["close"] <= stop_loss or row["close"] >= take_profit:
+                    balance = position * row["close"]
+                    position = 0.0
+                elif row["close"] < row["vwap"] or row["rsi"] > 70:
+                    balance = position * row["close"]
+                    position = 0.0
             equity.append(balance + position * row["close"])
+
         if position:
             balance = position * df.iloc[-1]["close"]
             equity[-1] = balance
+
         return pd.Series(equity, index=df.index[: len(equity)])
 
 

--- a/trading_bot/data_fetcher.py
+++ b/trading_bot/data_fetcher.py
@@ -1,6 +1,10 @@
+"""Utility helpers for retrieving OHLCV data from exchanges."""
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, List
+
 import ccxt
 import pandas as pd
-from datetime import datetime
 
 class DataFetcher:
     """Fetches market data from Binance via ccxt."""
@@ -26,10 +30,14 @@ class DataFetcher:
         return df
 
     def get_ohlcv_multi(
-        self, symbols: list[str], timeframe: str = "1m", limit: int = 200
-    ) -> dict[str, pd.DataFrame]:
-        """Fetch OHLCV data for multiple symbols."""
-        data = {}
-        for sym in symbols:
-            data[sym] = self.get_ohlcv(sym, timeframe=timeframe, limit=limit)
-        return data
+        self, symbols: List[str], timeframe: str = "1m", limit: int = 200
+    ) -> Dict[str, pd.DataFrame]:
+        """Fetch OHLCV data for multiple symbols concurrently."""
+
+        def fetch(sym: str) -> pd.DataFrame:
+            return self.get_ohlcv(sym, timeframe=timeframe, limit=limit)
+
+        with ThreadPoolExecutor(max_workers=min(len(symbols), 5)) as executor:
+            results = list(executor.map(fetch, symbols))
+
+        return dict(zip(symbols, results))

--- a/trading_bot/indicator_calculator.py
+++ b/trading_bot/indicator_calculator.py
@@ -1,3 +1,7 @@
+"""Technical indicator helpers used by the dashboard and strategies."""
+
+from typing import Dict
+
 import pandas as pd
 import pandas_ta as ta
 
@@ -45,3 +49,18 @@ def support_resistance(df: pd.DataFrame, window: int = 20):
     rolling_high = df['high'].rolling(window).max()
     rolling_low = df['low'].rolling(window).min()
     return rolling_low, rolling_high
+
+
+def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    """Run all indicator calculations on ``df``."""
+    df = add_indicators(df)
+    df = find_fractals(df)
+    lows, highs = support_resistance(df)
+    df["support"] = lows
+    df["resistance"] = highs
+    return df
+
+
+def compute_indicators_batch(data: Dict[str, pd.DataFrame]) -> Dict[str, pd.DataFrame]:
+    """Apply ``compute_indicators`` to each DataFrame in ``data``."""
+    return {sym: compute_indicators(df) for sym, df in data.items()}

--- a/trading_bot/tests/test_backtester.py
+++ b/trading_bot/tests/test_backtester.py
@@ -16,8 +16,8 @@ def test_backtest_returns_report():
         'rsi': [20, 40, 20],
         'close': [1.0, 1.1, 1.2]
     })
-    result = backtest(df)
-    assert result > 1.0
+    report = backtest(df)
+    assert report.final_balance > 1.0
 
 
 def test_stop_loss_triggered():
@@ -28,10 +28,9 @@ def test_stop_loss_triggered():
         'high': [1.1, 1.1, 1.05],
         'low': [0.9, 1.0, 0.75]
     })
-    result = backtest(df)
-    assert result < 1.0
     report = backtest(df)
-    assert report.final_balance > 1.0
+    assert report.final_balance < 1.0
+    assert report.num_trades > 0
 
 
 def test_backtest_creates_report_files(tmp_path):


### PR DESCRIPTION
## Summary
- allow Streamlit dashboard to load multiple trading pairs simultaneously
- fetch OHLCV data concurrently
- compute indicators in batch
- clean up backtester implementation
- update tests for new backtester API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604f442b50832ba33fe2dcb2fd6a5c

## Summary by Sourcery

Enable multi-symbol support in the Streamlit dashboard by fetching and processing OHLCV data concurrently, batch-computing indicators, refactoring the backtester to return an equity curve, and updating tests to match the new backtester API.

New Features:
- Support loading and displaying multiple trading pairs in the Streamlit dashboard
- Fetch OHLCV data concurrently for multiple symbols via a thread pool
- Compute technical indicators in batch for multi-symbol data

Enhancements:
- Refactor dashboard data loading into a single batch function and streamline tab-based rendering
- Refactor SimpleStrategy to generate and return an equity curve as a pandas Series

Tests:
- Update backtester tests to use the new Report API and assert final balance and trade count