### PR TITLE
Add selectable indicators to dashboard

### DIFF
--- a/trading_bot/app.py
+++ b/trading_bot/app.py
@@ -1,5 +1,8 @@
+"""Interactive Streamlit dashboard for visualising crypto data and indicators."""
+
+from __future__ import annotations
+
 import streamlit as st
-import pandas as pd
 import plotly.graph_objects as go
 from data_fetcher import DataFetcher
 from indicator_calculator import add_indicators, find_fractals, support_resistance
@@ -11,6 +14,19 @@ st.set_page_config(page_title="Crypto Dashboard", layout="wide")
 
 fetcher = DataFetcher()
 model = PriceDirectionModel()
+
+DEFAULT_INDICATORS = ["VWAP", "EMA", "SMA", "RSI", "MACD", "ADX", "Support", "Fractals"]
+
+if "selected_indicators" not in st.session_state:
+    st.session_state.selected_indicators = DEFAULT_INDICATORS.copy()
+
+st.sidebar.markdown("### Indicator Selection")
+selected_indicators = st.sidebar.multiselect(
+    "Indicators to display",
+    DEFAULT_INDICATORS,
+    default=st.session_state.selected_indicators,
+)
+st.session_state.selected_indicators = selected_indicators
 
 symbols_input = st.sidebar.text_input(
     "Trading Pairs (comma separated)", value="BTC/USDT"
@@ -46,6 +62,7 @@ for sym, tab in zip(symbols, tabs):
         model_prob = model.predict(data)
 
         st.metric("Current Price", current_price)
+
         fig = go.Figure(
             data=[
                 go.Candlestick(
@@ -57,78 +74,72 @@ for sym, tab in zip(symbols, tabs):
                 )
             ]
         )
-        fig.add_trace(go.Scatter(x=data["timestamp"], y=data["vwap"], name="VWAP"))
-        fig.add_trace(go.Scatter(x=data["timestamp"], y=data["ema"], name="EMA"))
-        fig.add_trace(go.Scatter(x=data["timestamp"], y=data["sma"], name="SMA"))
-        fig.add_trace(
-            go.Scatter(x=data["timestamp"], y=data["support"], name="Support", line=dict(dash="dot"))
-        )
-        fig.add_trace(
-            go.Scatter(x=data["timestamp"], y=data["resistance"], name="Resistance", line=dict(dash="dot"))
-        )
-        fractals_up = data[data["fractal_up"]]
-        fractals_down = data[data["fractal_down"]]
-        fig.add_trace(
-            go.Scatter(
-                x=fractals_up["timestamp"],
-                y=fractals_up["high"],
-                mode="markers",
-                marker_symbol="triangle-up",
-                marker_color="green",
-                name="Fractal Up",
+
+        if "VWAP" in selected_indicators:
+            fig.add_trace(go.Scatter(x=data["timestamp"], y=data["vwap"], name="VWAP"))
+        if "EMA" in selected_indicators:
+            fig.add_trace(go.Scatter(x=data["timestamp"], y=data["ema"], name="EMA"))
+        if "SMA" in selected_indicators:
+            fig.add_trace(go.Scatter(x=data["timestamp"], y=data["sma"], name="SMA"))
+        if "Support" in selected_indicators:
+            fig.add_trace(
+                go.Scatter(x=data["timestamp"], y=data["support"], name="Support", line=dict(dash="dot"))
             )
-        )
-        fig.add_trace(
-            go.Scatter(
-                x=fractals_down["timestamp"],
-                y=fractals_down["low"],
-                mode="markers",
-                marker_symbol="triangle-down",
-                marker_color="red",
-                name="Fractal Down",
+            fig.add_trace(
+                go.Scatter(x=data["timestamp"], y=data["resistance"], name="Resistance", line=dict(dash="dot"))
             )
-        )
+        if "Fractals" in selected_indicators:
+            fractals_up = data[data["fractal_up"]]
+            fractals_down = data[data["fractal_down"]]
+            fig.add_trace(
+                go.Scatter(
+                    x=fractals_up["timestamp"],
+                    y=fractals_up["high"],
+                    mode="markers",
+                    marker_symbol="triangle-up",
+                    marker_color="green",
+                    name="Fractal Up",
+                )
+            )
+            fig.add_trace(
+                go.Scatter(
+                    x=fractals_down["timestamp"],
+                    y=fractals_down["low"],
+                    mode="markers",
+                    marker_symbol="triangle-down",
+                    marker_color="red",
+                    name="Fractal Down",
+                )
+            )
+
+        if "RSI" in selected_indicators:
+            fig.add_trace(
+                go.Scatter(x=data["timestamp"], y=data["rsi"], name="RSI", yaxis="y2")
+            )
+        if "MACD" in selected_indicators:
+            fig.add_trace(
+                go.Scatter(x=data["timestamp"], y=data["macd"], name="MACD", yaxis="y2")
+            )
+            fig.add_trace(
+                go.Scatter(
+                    x=data["timestamp"],
+                    y=data["macd_signal"],
+                    name="MACD Signal",
+                    yaxis="y2",
+                )
+            )
+        if "ADX" in selected_indicators:
+            fig.add_trace(
+                go.Scatter(x=data["timestamp"], y=data["adx"], name="ADX", yaxis="y2")
+            )
+
+        fig.update_layout(yaxis2=dict(overlaying="y", side="right", title="Oscillators"))
 
         st.plotly_chart(fig, use_container_width=True)
 
         col1, col2 = st.columns(2)
         col1.write(f"Sentiment score: {sentiment_score}")
         col2.write(f"Model long probability: {model_prob}")
-
-data = load_data()
-current_price = fetcher.get_current_price(symbol)
-
-if run_backtest:
-    report = backtest(data, report_dir="trading_bot/reports")
-    st.sidebar.write(f"Backtest balance: {report.final_balance:.2f}")
-    st.sidebar.write(f"Profit: {report.profit:.2f}")
-    st.sidebar.write(f"Max DD: {report.max_drawdown:.2%}")
-    st.sidebar.write(f"Trades: {report.num_trades}")
-    if report.figure_path:
-        st.image(report.figure_path)
-
-sentiment_score = analyze_sentiment([])
-model_prob = model.predict(data)
-
-st.metric("Current Price", current_price)
-fig = go.Figure(data=[go.Candlestick(x=data['timestamp'],
-                open=data['open'], high=data['high'],
-                low=data['low'], close=data['close'])])
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['vwap'], name='VWAP'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['ema'], name='EMA'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['sma'], name='SMA'))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['support'], name='Support', line=dict(dash='dot')))
-fig.add_trace(go.Scatter(x=data['timestamp'], y=data['resistance'], name='Resistance', line=dict(dash='dot')))
-fractals_up = data[data['fractal_up']]
-fractals_down = data[data['fractal_down']]
-fig.add_trace(go.Scatter(x=fractals_up['timestamp'], y=fractals_up['high'], mode='markers', marker_symbol='triangle-up', marker_color='green', name='Fractal Up'))
-fig.add_trace(go.Scatter(x=fractals_down['timestamp'], y=fractals_down['low'], mode='markers', marker_symbol='triangle-down', marker_color='red', name='Fractal Down'))
-
-st.plotly_chart(fig, use_container_width=True)
-
-col1, col2 = st.columns(2)
-col1.write(f"Sentiment score: {sentiment_score}")
-col2.write(f"Model long probability: {model_prob}")
 
 if refresh_btn:
     st.experimental_rerun()

--- a/trading_bot/indicator_calculator.py
+++ b/trading_bot/indicator_calculator.py
@@ -1,3 +1,7 @@
+"""Utility functions for calculating common technical indicators."""
+
+from __future__ import annotations
+
 import pandas as pd
 import pandas_ta as ta
 
@@ -16,6 +20,10 @@ def add_indicators(df: pd.DataFrame) -> pd.DataFrame:
         df["adx"] = adx
     else:
         df["adx"] = pd.NA
+    macd = ta.macd(df["close"], fast=12, slow=26, signal=9)
+    if isinstance(macd, pd.DataFrame):
+        df["macd"] = macd.iloc[:, 0]
+        df["macd_signal"] = macd.iloc[:, 1]
     df["ema"] = ta.ema(df["close"], length=20)
     df["sma"] = ta.sma(df["close"], length=20)
 


### PR DESCRIPTION
## Summary
- enable configurable indicators in Streamlit via session state
- calculate MACD in `indicator_calculator`
- plot RSI, MACD, ADX, etc. conditionally on user selection
- clean up duplicated code in `app.py`

## Testing
- `pytest -q` *(fails: TypeError in `test_backtester`)*

------
https://chatgpt.com/codex/tasks/task_e_68604f436774832bb1b68f1e1222ff0f

## Summary by Sourcery

Introduce selectable chart indicators to the dashboard by adding a sidebar multiselect, compute MACD values in the indicator calculator, and refactor plotting logic to conditionally render user-chosen indicators.

New Features:
- Add sidebar multiselect for users to pick which technical indicators to display, persisting choices in session state
- Compute MACD and MACD signal line in indicator_calculator
- Enable conditional plotting of selected indicators (VWAP, EMA, SMA, RSI, MACD, ADX, Support, Fractals) in the main dashboard

Enhancements:
- Remove duplicate plotting code and consolidate indicator rendering logic in app.py
- Overlay oscillators (RSI, MACD, ADX) on a secondary y-axis in plot layout